### PR TITLE
Apply modern Apple-inspired theme

### DIFF
--- a/Bestuff/Sources/AddEditItem/AddItemView.swift
+++ b/Bestuff/Sources/AddEditItem/AddItemView.swift
@@ -131,6 +131,7 @@ struct AddItemView: View {
                     }
                 }
             }
+            .scrollContentBackground(.hidden)
             .navigationTitle("Add Item")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -161,5 +162,7 @@ struct AddItemView: View {
                 }
             }
         }
+        .appNavigationStyle()
+        .appBackground()
     }
 }

--- a/Bestuff/Sources/AddEditItem/EditItemView.swift
+++ b/Bestuff/Sources/AddEditItem/EditItemView.swift
@@ -106,6 +106,7 @@ struct EditItemView: View {
                     }
                 }
             }
+            .scrollContentBackground(.hidden)
             .navigationTitle("Edit Item")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -144,6 +145,8 @@ struct EditItemView: View {
                 tags = item.tags
             }
         }
+        .appNavigationStyle()
+        .appBackground()
     }
 
     private var tagSuggestions: [String] {

--- a/Bestuff/Sources/AddEditItem/ItemDetailView.swift
+++ b/Bestuff/Sources/AddEditItem/ItemDetailView.swift
@@ -59,7 +59,9 @@ struct ItemDetailView: View {
             }
             .padding()
         }
+        .appBackground()
         .navigationTitle("Item Details")
+        .appNavigationStyle()
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button("Edit") {

--- a/Bestuff/Sources/Insights/InsightsCard.swift
+++ b/Bestuff/Sources/Insights/InsightsCard.swift
@@ -19,7 +19,7 @@ struct InsightsCard<Content: View>: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text(title)
-                .font(.headline)
+                .font(AppFont.title)
                 .foregroundStyle(.primary)
             content
         }

--- a/Bestuff/Sources/Insights/InsightsView.swift
+++ b/Bestuff/Sources/Insights/InsightsView.swift
@@ -306,6 +306,8 @@ struct InsightsView: View {
             }
 
         }
+        .appNavigationStyle()
+        .appBackground()
         .alert(item: $pendingDeletion) { item in
             Alert(
                 title: Text("Delete Item"),

--- a/Bestuff/Sources/ItemList/BestItemListView.swift
+++ b/Bestuff/Sources/ItemList/BestItemListView.swift
@@ -66,6 +66,8 @@ struct BestItemListView: View {
                     }
                 }
             }
+            .listStyle(.insetGrouped)
+            .scrollContentBackground(.hidden)
             .navigationTitle("Your Best Picks")
             .toolbar {
                 BestItemListToolbar(
@@ -98,6 +100,8 @@ struct BestItemListView: View {
                 ItemDetailView(item: item)
             }
         }
+        .appNavigationStyle()
+        .appBackground()
     }
 }
 

--- a/Bestuff/Sources/ItemList/BestItemSectionView.swift
+++ b/Bestuff/Sources/ItemList/BestItemSectionView.swift
@@ -60,6 +60,8 @@ struct BestItemSectionView: View {
                     }
                 }
                 .bestCardStyle(using: item.gradient)
+                .listRowInsets(.init())
+                .listRowSeparator(.hidden)
                 .contextMenu {
                     Button {
                         navigation.selectedItem = item

--- a/Bestuff/Sources/ItemList/EmptyPlaceholderView.swift
+++ b/Bestuff/Sources/ItemList/EmptyPlaceholderView.swift
@@ -15,9 +15,9 @@ struct EmptyPlaceholderView: View {
                     .font(.system(size: 40))
                     .foregroundColor(.accentColor)
                 Text("Start tracking your favorites!")
-                    .font(.headline)
+                    .font(AppFont.title)
                 Text("Tap the + button to add your first Best Item.")
-                    .font(.subheadline)
+                    .font(AppFont.body)
                     .foregroundStyle(.secondary)
             }
             .frame(maxWidth: .infinity)

--- a/Bestuff/Sources/ItemList/NoMatchesView.swift
+++ b/Bestuff/Sources/ItemList/NoMatchesView.swift
@@ -16,10 +16,10 @@ struct NoMatchesView: View {
         Section {
             VStack(alignment: .center, spacing: 12) {
                 Text("No matching items found.")
-                    .font(.headline)
+                    .font(AppFont.title)
                 if searchText.isEmpty {
                     Text("Here are some of your recent top-rated items:")
-                        .font(.subheadline)
+                        .font(AppFont.body)
                         .foregroundStyle(.secondary)
 
                     let recentItems = allItems

--- a/Bestuff/Sources/ItemList/TagPickerView.swift
+++ b/Bestuff/Sources/ItemList/TagPickerView.swift
@@ -39,6 +39,7 @@ struct TagPickerView: View {
                     }
                 }
             }
+            .scrollContentBackground(.hidden)
             .searchable(text: $searchText)
             .navigationTitle("Select Tags")
             .toolbar {
@@ -55,5 +56,7 @@ struct TagPickerView: View {
                 }
             }
         }
+        .appNavigationStyle()
+        .appBackground()
     }
 }

--- a/Bestuff/Sources/Recap/RecapView.swift
+++ b/Bestuff/Sources/Recap/RecapView.swift
@@ -95,6 +95,8 @@ struct RecapView: View {
                 ItemDetailView(item: item)
             }
         }
+        .appNavigationStyle()
+        .appBackground()
         .sheet(item: $navigation.editingItem) { item in
             EditItemView(item: item, isPresented: $navigation.editingItem)
         }

--- a/Bestuff/Sources/Root/ContentView.swift
+++ b/Bestuff/Sources/Root/ContentView.swift
@@ -34,6 +34,7 @@ struct ContentView: View {
                 }
                 .tag(3)
         }
+        .appBackground()
     }
 }
 

--- a/Bestuff/Sources/Settings/SettingsView.swift
+++ b/Bestuff/Sources/Settings/SettingsView.swift
@@ -89,7 +89,10 @@ struct SettingsView: View {
                     Toggle("Enable Haptics", isOn: $hapticsEnabled)
                 }
             }
+            .scrollContentBackground(.hidden)
             .navigationTitle("Settings")
         }
+        .appNavigationStyle()
+        .appBackground()
     }
 }

--- a/Bestuff/Sources/Shared/Components/AppStyleModifiers.swift
+++ b/Bestuff/Sources/Shared/Components/AppStyleModifiers.swift
@@ -1,0 +1,36 @@
+//
+//  AppStyleModifiers.swift
+//  Bestuff
+//
+//  Created by Codex on 2025/06/04.
+//
+
+import SwiftUI
+
+struct AppBackgroundModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .background {
+                AppTheme.gradient
+                    .ignoresSafeArea()
+            }
+    }
+}
+
+struct NavigationStyleModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .toolbarBackground(AppTheme.gradient, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
+    }
+}
+
+extension View {
+    func appBackground() -> some View {
+        modifier(AppBackgroundModifier())
+    }
+
+    func appNavigationStyle() -> some View {
+        modifier(NavigationStyleModifier())
+    }
+}

--- a/Bestuff/Sources/Shared/Components/CardViewModifier.swift
+++ b/Bestuff/Sources/Shared/Components/CardViewModifier.swift
@@ -14,11 +14,19 @@ struct CardViewModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .padding()
-            .background(background)
-            .clipShape(RoundedRectangle(cornerRadius: DesignMetrics.cornerRadius, style: .continuous))
-            .shadow(color: .black.opacity(isTopItem ? 0.1 : DesignMetrics.shadowOpacity),
-                    radius: isTopItem ? 10 : DesignMetrics.shadowRadius,
-                    x: 0, y: isTopItem ? 4 : 2)
+            .background {
+                background
+                    .overlay(AppTheme.gradient.opacity(0.3))
+                    .overlay(.thinMaterial)
+                    .clipShape(RoundedRectangle(cornerRadius: DesignMetrics.cornerRadius, style: .continuous))
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: DesignMetrics.cornerRadius, style: .continuous)
+                    .stroke(Color.white.opacity(0.3))
+            )
+            .shadow(color: .black.opacity(isTopItem ? 0.3 : DesignMetrics.shadowOpacity),
+                    radius: isTopItem ? 14 : DesignMetrics.shadowRadius,
+                    x: 0, y: isTopItem ? 7 : 3)
     }
 }
 

--- a/Bestuff/Sources/Shared/Utilities/AppFont.swift
+++ b/Bestuff/Sources/Shared/Utilities/AppFont.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 enum AppFont {
-    static let title = Font.title3.weight(.semibold)
-    static let body = Font.subheadline
-    static let caption = Font.caption2
+    static let title = Font.system(.title3, design: .rounded).weight(.semibold)
+    static let body = Font.system(.subheadline, design: .rounded)
+    static let caption = Font.system(.caption2, design: .rounded)
 }

--- a/Bestuff/Sources/Shared/Utilities/AppTheme.swift
+++ b/Bestuff/Sources/Shared/Utilities/AppTheme.swift
@@ -1,0 +1,20 @@
+//
+//  AppTheme.swift
+//  Bestuff
+//
+//  Created by Codex on 2025/06/04.
+//
+
+import SwiftUI
+
+enum AppTheme {
+    static let gradient = LinearGradient(
+        colors: [
+            Color.accentColor.opacity(0.8),
+            Color.purple.opacity(0.6),
+            Color.blue.opacity(0.6)
+        ],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+}

--- a/Bestuff/Sources/Shared/Utilities/DesignMetrics.swift
+++ b/Bestuff/Sources/Shared/Utilities/DesignMetrics.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum DesignMetrics {
-    static let cornerRadius: CGFloat = 12
-    static let shadowRadius: CGFloat = 4
-    static let shadowOpacity: Double = 0.05
+    static let cornerRadius: CGFloat = 16
+    static let shadowRadius: CGFloat = 6
+    static let shadowOpacity: Double = 0.1
 }


### PR DESCRIPTION
## Summary
- add AppTheme gradient and style modifiers for backgrounds and nav bars
- adjust design metrics for softer rounded cards
- overlay cards with gradient and stronger shadows
- refresh primary views to use new app style

## Testing
- `swiftc -parse Bestuff/Sources/Shared/Utilities/AppTheme.swift`
- `swiftc -parse Bestuff/Sources/Shared/Components/AppStyleModifiers.swift`
- `swiftc -parse Bestuff/Sources/Shared/Components/CardViewModifier.swift`
- `swiftc -parse Bestuff/Sources/ItemList/BestItemListView.swift`
- `swiftc -parse Bestuff/Sources/AddEditItem/AddItemView.swift`
- `swiftc -parse Bestuff/Sources/AddEditItem/EditItemView.swift`
- `swiftc -parse Bestuff/Sources/AddEditItem/ItemDetailView.swift`
- `swiftc -parse Bestuff/Sources/Recap/RecapView.swift`
- `swiftc -parse Bestuff/Sources/Insights/InsightsView.swift`
- `swiftc -parse Bestuff/Sources/Settings/SettingsView.swift`
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_68400cd791188320bd052c4c0a83e201