### PR TITLE
Add domain intents and tests

### DIFF
--- a/Bestuff/Intents/Stuff/CreateStuffIntent.swift
+++ b/Bestuff/Intents/Stuff/CreateStuffIntent.swift
@@ -1,0 +1,35 @@
+import AppIntents
+import SwiftData
+
+struct CreateStuffIntent: AppIntent {
+    typealias Input = (context: ModelContext, title: String, category: String, note: String?)
+    typealias Output = StuffEntity
+
+    @Parameter(title: "Title")
+    private var title: String
+
+    @Parameter(title: "Category")
+    private var category: String
+
+    @Parameter(title: "Note")
+    private var note: String?
+
+    @Dependency private var modelContainer: ModelContainer
+
+    static let title: LocalizedStringResource = "Create Stuff"
+
+    static func perform(_ input: Input) throws -> Output {
+        let (context, title, category, note) = input
+        let model = Stuff(title: title, category: category, note: note)
+        context.insert(model)
+        guard let entity = StuffEntity(model) else {
+            throw StuffError.stuffNotFound
+        }
+        return entity
+    }
+
+    func perform() throws -> some ReturnsValue<StuffEntity> {
+        let result = try Self.perform((context: modelContainer.mainContext, title: title, category: category, note: note))
+        return .result(value: result)
+    }
+}

--- a/Bestuff/Intents/Stuff/DeleteStuffIntent.swift
+++ b/Bestuff/Intents/Stuff/DeleteStuffIntent.swift
@@ -1,0 +1,25 @@
+import AppIntents
+import SwiftData
+
+struct DeleteStuffIntent: AppIntent {
+    typealias Input = (context: ModelContext, item: StuffEntity)
+    typealias Output = Void
+
+    @Parameter(title: "Stuff")
+    private var item: StuffEntity
+
+    @Dependency private var modelContainer: ModelContainer
+
+    static let title: LocalizedStringResource = "Delete Stuff"
+
+    static func perform(_ input: Input) throws -> Output {
+        let (context, entity) = input
+        let model = try entity.model(in: context)
+        context.delete(model)
+    }
+
+    func perform() throws -> some IntentResult {
+        try Self.perform((context: modelContainer.mainContext, item: item))
+        return .result()
+    }
+}

--- a/Bestuff/Intents/Stuff/StuffEntity.swift
+++ b/Bestuff/Intents/Stuff/StuffEntity.swift
@@ -1,0 +1,43 @@
+import AppIntents
+import SwiftData
+
+@Observable
+final class StuffEntity: AppEntity {
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = .init(name: "Stuff")
+    static var defaultQuery = StuffEntityQuery()
+
+    var displayRepresentation: DisplayRepresentation {
+        .init(title: title, subtitle: category)
+    }
+
+    let id: String
+    let title: String
+    let category: String
+    let note: String?
+
+    fileprivate init(id: String, title: String, category: String, note: String?) {
+        self.id = id
+        self.title = title
+        self.category = category
+        self.note = note
+    }
+}
+
+extension StuffEntity {
+    convenience init?(_ model: Stuff) {
+        guard let encodedID = try? model.id.base64Encoded() else {
+            return nil
+        }
+        self.init(id: encodedID, title: model.title, category: model.category, note: model.note)
+    }
+
+    func model(in context: ModelContext) throws -> Stuff {
+        guard
+            let id = try? PersistentIdentifier(base64Encoded: id),
+            let model = try context.fetch(FetchDescriptor<Stuff>(predicate: #Predicate { $0.id == id })).first
+        else {
+            throw StuffError.stuffNotFound
+        }
+        return model
+    }
+}

--- a/Bestuff/Intents/Stuff/StuffEntityQuery.swift
+++ b/Bestuff/Intents/Stuff/StuffEntityQuery.swift
@@ -1,0 +1,38 @@
+import AppIntents
+import SwiftData
+
+struct StuffEntityQuery: EntityStringQuery {
+    @Dependency private var modelContainer: ModelContainer
+
+    func entities(for identifiers: [StuffEntity.ID]) throws -> [StuffEntity] {
+        try identifiers.compactMap { encodedID in
+            guard
+                let id = try? PersistentIdentifier(base64Encoded: encodedID),
+                let model = try modelContainer.mainContext.fetch(
+                    FetchDescriptor<Stuff>(predicate: #Predicate { $0.id == id })
+                ).first
+            else {
+                return nil
+            }
+            return StuffEntity(model)
+        }
+    }
+
+    func entities(matching string: String) throws -> [StuffEntity] {
+        try modelContainer.mainContext.fetch(
+            FetchDescriptor<Stuff>(predicate: #Predicate {
+                $0.title.localizedStandardContains(string) ||
+                    $0.category.localizedStandardContains(string)
+            })
+        ).compactMap(StuffEntity.init)
+    }
+
+    func suggestedEntities() throws -> [StuffEntity] {
+        try modelContainer.mainContext.fetch(
+            FetchDescriptor(
+                sortBy: [SortDescriptor(\Stuff.createdAt, order: .reverse)],
+                fetchLimit: 5
+            )
+        ).compactMap(StuffEntity.init)
+    }
+}

--- a/Bestuff/Intents/Stuff/StuffError.swift
+++ b/Bestuff/Intents/Stuff/StuffError.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+enum StuffError: Error {
+    case stuffNotFound
+}

--- a/Bestuff/StuffFormView.swift
+++ b/Bestuff/StuffFormView.swift
@@ -40,8 +40,14 @@ struct StuffFormView: View {
 
     private func save() {
         withAnimation {
-            let newItem = Stuff(title: title, category: category, note: note.isEmpty ? nil : note)
-            modelContext.insert(newItem)
+            _ = try? CreateStuffIntent.perform(
+                (
+                    context: modelContext,
+                    title: title,
+                    category: category,
+                    note: note.isEmpty ? nil : note
+                )
+            )
             dismiss()
         }
     }

--- a/Bestuff/StuffListView.swift
+++ b/Bestuff/StuffListView.swift
@@ -47,7 +47,12 @@ struct StuffListView: View {
 
     private func delete(at offsets: IndexSet) {
         withAnimation {
-            offsets.map { items[$0] }.forEach(modelContext.delete)
+            for index in offsets {
+                let item = items[index]
+                if let entity = StuffEntity(item) {
+                    try? DeleteStuffIntent.perform((context: modelContext, item: entity))
+                }
+            }
         }
     }
 }

--- a/BestuffTests/CreateStuffIntentTests.swift
+++ b/BestuffTests/CreateStuffIntentTests.swift
@@ -1,0 +1,21 @@
+@testable import Bestuff
+import SwiftData
+import Testing
+
+@MainActor
+struct CreateStuffIntentTests {
+    let context: ModelContext
+
+    init() {
+        context = testContext
+    }
+
+    @Test func perform() throws {
+        let _ = try CreateStuffIntent.perform(
+            (context: context, title: "Title", category: "General", note: nil)
+        )
+        let items = try context.fetch(FetchDescriptor<Stuff>())
+        #expect(items.count == 1)
+        #expect(items.first?.title == "Title")
+    }
+}

--- a/BestuffTests/DeleteStuffIntentTests.swift
+++ b/BestuffTests/DeleteStuffIntentTests.swift
@@ -1,0 +1,22 @@
+@testable import Bestuff
+import SwiftData
+import Testing
+
+@MainActor
+struct DeleteStuffIntentTests {
+    let context: ModelContext
+
+    init() {
+        context = testContext
+    }
+
+    @Test func perform() throws {
+        let entity = try CreateStuffIntent.perform(
+            (context: context, title: "Title", category: "General", note: nil)
+        )
+        #expect(try context.fetch(FetchDescriptor<Stuff>()).count == 1)
+        try DeleteStuffIntent.perform((context: context, item: entity))
+        let items = try context.fetch(FetchDescriptor<Stuff>())
+        #expect(items.isEmpty)
+    }
+}

--- a/BestuffTests/TestUtilities.swift
+++ b/BestuffTests/TestUtilities.swift
@@ -1,0 +1,7 @@
+import SwiftData
+
+let testContext: ModelContext = {
+    let schema = Schema([Stuff.self])
+    let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+    return try! ModelContainer(for: schema, configurations: [configuration]).mainContext
+}()


### PR DESCRIPTION
## Summary
- add `StuffEntity` and query for AppIntent bridging
- provide `CreateStuffIntent` and `DeleteStuffIntent`
- call new intents from views
- include test utilities for in-memory context
- add unit tests for the new intents

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d385dcb548320b0db3967a19b3b9c