### PR TITLE
Add settings and debug screens

### DIFF
--- a/Bestuff/DebugView.swift
+++ b/Bestuff/DebugView.swift
@@ -1,0 +1,80 @@
+//
+//  DebugView.swift
+//  Bestuff
+//
+//  Created by Codex on 2025/07/09.
+//
+
+import SwiftData
+import SwiftUI
+
+struct DebugView: View {
+    @Environment(\.modelContext) private var modelContext
+    @State private var isAlertPresented = false
+
+    var body: some View {
+        List {
+            Section("Information") {
+                HStack {
+                    Text("App Version")
+                    Spacer()
+                    Text("1.0.0")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Section("Actions") {
+                Button {
+                    isAlertPresented = true
+                } label: {
+                    Text("Create Sample Data")
+                }
+            }
+        }
+        .alert(
+            "Create sample data?",
+            isPresented: $isAlertPresented
+        ) {
+            Button("Cancel", role: .cancel) {}
+            Button("Create") { createSampleData() }
+        } message: {
+            Text("This will add example items to the list.")
+        }
+        .navigationTitle(Text("Debug"))
+    }
+
+    private func createSampleData() {
+        withAnimation {
+            for item in SampleData.items {
+                _ = try? CreateStuffIntent.perform(
+                    (
+                        context: modelContext,
+                        title: item.title,
+                        category: item.category,
+                        note: item.note
+                    )
+                )
+            }
+        }
+    }
+}
+
+struct SampleData {
+    struct Item {
+        let title: String
+        let category: String
+        let note: String?
+    }
+
+    static let items: [Item] = [
+        .init(title: "Coffee Beans", category: "Groceries", note: "Order from the local roastery."),
+        .init(title: "Running Shoes", category: "Fitness", note: "Replace the worn-out pair."),
+        .init(title: "Conference Tickets", category: "Work", note: "WWDC 2025"),
+        .init(title: "Vacation Booking", category: "Travel", note: "Reserve hotel and flights."),
+        .init(title: "Birthday Gift", category: "Personal", note: "Surprise for Alice.")
+    ]
+}
+
+#Preview {
+    NavigationStack { DebugView() }
+        .modelContainer(for: Stuff.self, inMemory: true)
+}

--- a/Bestuff/SettingsView.swift
+++ b/Bestuff/SettingsView.swift
@@ -1,0 +1,32 @@
+//
+//  SettingsView.swift
+//  Bestuff
+//
+//  Created by Codex on 2025/07/09.
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("General") {
+                    Label("Version 1.0.0", systemImage: "number")
+                }
+                Section("Debug") {
+                    NavigationLink {
+                        DebugView()
+                    } label: {
+                        Text("Debug")
+                    }
+                }
+            }
+            .navigationTitle(Text("Settings"))
+        }
+    }
+}
+
+#Preview {
+    SettingsView()
+}

--- a/Bestuff/StuffListView.swift
+++ b/Bestuff/StuffListView.swift
@@ -12,6 +12,7 @@ struct StuffListView: View {
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \Stuff.createdAt, order: .reverse) private var items: [Stuff]
     @State private var searchText = ""
+    @State private var isSettingsPresented = false
 
     var body: some View {
         NavigationStack {
@@ -30,6 +31,14 @@ struct StuffListView: View {
             .navigationTitle(Text("Best Stuff"))
             .toolbar {
                 AddStuffButton()
+                Button {
+                    isSettingsPresented = true
+                } label: {
+                    Label("Settings", systemImage: "gearshape")
+                }
+            }
+            .sheet(isPresented: $isSettingsPresented) {
+                SettingsView()
             }
         }
     }


### PR DESCRIPTION
## Summary
- provide a Settings screen that links to a Debug screen
- implement Debug screen with sample data creation
- show Settings from the Stuff list

## Testing
- `pre-commit run --files Bestuff/StuffListView.swift Bestuff/DebugView.swift Bestuff/SettingsView.swift` *(fails: RPC error 403 from github.com)*

------
https://chatgpt.com/codex/tasks/task_e_686da90eca008320b05872c642390f39