### PR TITLE
Improve predicted stuff intent

### DIFF
--- a/Bestuff/Intents/Stuff/PredictStuffIntent.swift
+++ b/Bestuff/Intents/Stuff/PredictStuffIntent.swift
@@ -1,0 +1,52 @@
+import AppIntents
+import FoundationModels
+import SwiftData
+import SwiftUtilities
+
+struct PredictStuffIntent: AppIntent, IntentPerformer {
+    typealias Input = (context: ModelContext, speech: String)
+    typealias Output = Stuff
+
+    nonisolated static var title: LocalizedStringResource {
+        "Predict Stuff"
+    }
+
+    @Parameter(title: "Speech")
+    private var speech: String
+
+    @Dependency private var modelContainer: ModelContainer
+
+    static func perform(_ input: Input) async throws -> Output {
+        let (context, speech) = input
+        let prediction = try await generatePrediction(from: speech)
+        let model = Stuff(
+            title: prediction.title,
+            category: prediction.category,
+            note: prediction.note,
+            score: prediction.score
+        )
+        context.insert(model)
+        return model
+    }
+
+    func perform() async throws -> some ReturnsValue<StuffEntity> {
+        let model = try await Self.perform((context: modelContainer.mainContext, speech: speech))
+        guard let entity = StuffEntity(model) else {
+            throw StuffError.stuffNotFound
+        }
+        return .result(value: entity)
+    }
+
+    private static func generatePrediction(from text: String) async throws -> StuffEntity {
+        let prompt = """
+            Based on the following user speech, guess a title, category, optional note and a score from 0 to 100 for an item the user might want to create.
+            Speech: \(text)
+            """
+        let session = LanguageModelSession()
+        let response = try await session.respond(
+            to: prompt,
+            generating: StuffEntity.self
+        )
+        return response.content
+    }
+}

--- a/Bestuff/Intents/Stuff/StuffEntity.swift
+++ b/Bestuff/Intents/Stuff/StuffEntity.swift
@@ -1,10 +1,11 @@
 import AppIntents
+import FoundationModels
 import SwiftData
 import SwiftUtilities
 
 @Generable
 nonisolated struct StuffEntity {
-    let id: String?
+    let id: String
     let title: String
     let category: String
     let note: String?
@@ -12,7 +13,6 @@ nonisolated struct StuffEntity {
 }
 
 extension StuffEntity: AppEntity {
-    typealias ID = String?
     static var typeDisplayRepresentation: TypeDisplayRepresentation {
         .init(name: "Stuff")
     }
@@ -43,13 +43,10 @@ extension StuffEntity: ModelBridgeable {
     }
 
     func model(in context: ModelContext) throws -> Stuff {
-        guard
-            let encodedID = id,
-            let id = try? PersistentIdentifier(base64Encoded: encodedID),
-            let model = try context.fetch(
-                FetchDescriptor<Stuff>(predicate: #Predicate { $0.id == id })
-            ).first
-        else {
+        guard let persistentID = try? PersistentIdentifier(base64Encoded: id),
+              let model = try context.fetch(
+                FetchDescriptor<Stuff>(predicate: #Predicate { $0.id == persistentID })
+              ).first else {
             throw StuffError.stuffNotFound
         }
         return model

--- a/Bestuff/Intents/Stuff/StuffEntity.swift
+++ b/Bestuff/Intents/Stuff/StuffEntity.swift
@@ -2,21 +2,17 @@ import AppIntents
 import SwiftData
 import SwiftUtilities
 
+@Generable
 nonisolated struct StuffEntity {
-    let id: String
+    let id: String?
     let title: String
     let category: String
     let note: String?
-
-    private init(id: String, title: String, category: String, note: String?) {
-        self.id = id
-        self.title = title
-        self.category = category
-        self.note = note
-    }
+    let score: Int
 }
 
 extension StuffEntity: AppEntity {
+    typealias ID = String?
     static var typeDisplayRepresentation: TypeDisplayRepresentation {
         .init(name: "Stuff")
     }
@@ -37,12 +33,23 @@ extension StuffEntity: ModelBridgeable {
         guard let encodedID = try? model.id.base64Encoded() else {
             return nil
         }
-        self.init(id: encodedID, title: model.title, category: model.category, note: model.note)
+        self.init(
+            id: encodedID,
+            title: model.title,
+            category: model.category,
+            note: model.note,
+            score: model.score
+        )
     }
 
     func model(in context: ModelContext) throws -> Stuff {
-        guard let id = try? PersistentIdentifier(base64Encoded: id),
-              let model = try context.fetch(FetchDescriptor<Stuff>(predicate: #Predicate { $0.id == id })).first else {
+        guard
+            let encodedID = id,
+            let id = try? PersistentIdentifier(base64Encoded: encodedID),
+            let model = try context.fetch(
+                FetchDescriptor<Stuff>(predicate: #Predicate { $0.id == id })
+            ).first
+        else {
             throw StuffError.stuffNotFound
         }
         return model

--- a/Bestuff/Intents/Stuff/StuffEntityQuery.swift
+++ b/Bestuff/Intents/Stuff/StuffEntityQuery.swift
@@ -7,13 +7,10 @@ struct StuffEntityQuery: EntityStringQuery {
 
     func entities(for identifiers: [StuffEntity.ID]) throws -> [StuffEntity] {
         try identifiers.compactMap { encodedID in
-            guard
-                let encodedID,
-                let id = try? PersistentIdentifier(base64Encoded: encodedID),
-                let model = try modelContainer.mainContext.fetch(
-                    FetchDescriptor<Stuff>(predicate: #Predicate { $0.id == id })
-                ).first
-            else {
+            guard let persistentID = try? PersistentIdentifier(base64Encoded: encodedID),
+                  let model = try modelContainer.mainContext.fetch(
+                    FetchDescriptor<Stuff>(predicate: #Predicate { $0.id == persistentID })
+                  ).first else {
                 return nil
             }
             return StuffEntity(model)

--- a/Bestuff/Intents/Stuff/StuffEntityQuery.swift
+++ b/Bestuff/Intents/Stuff/StuffEntityQuery.swift
@@ -8,6 +8,7 @@ struct StuffEntityQuery: EntityStringQuery {
     func entities(for identifiers: [StuffEntity.ID]) throws -> [StuffEntity] {
         try identifiers.compactMap { encodedID in
             guard
+                let encodedID,
                 let id = try? PersistentIdentifier(base64Encoded: encodedID),
                 let model = try modelContainer.mainContext.fetch(
                     FetchDescriptor<Stuff>(predicate: #Predicate { $0.id == id })

--- a/Bestuff/Stuff.swift
+++ b/Bestuff/Stuff.swift
@@ -13,12 +13,20 @@ nonisolated final class Stuff {
     var title: String
     var category: String
     var note: String?
+    var score: Int
     var createdAt: Date
 
-    init(title: String, category: String, note: String? = nil, createdAt: Date = .now) {
+    init(
+        title: String,
+        category: String,
+        note: String? = nil,
+        score: Int = 0,
+        createdAt: Date = .now
+    ) {
         self.title = title
         self.category = category
         self.note = note
+        self.score = score
         self.createdAt = createdAt
     }
 }


### PR DESCRIPTION
## Summary
- make `StuffEntity` a Generable type so it can be produced by Foundation Models
- allow `StuffEntity.id` to be optional and update model bridging
- update `PredictStuffIntent` to generate a `StuffEntity` directly

## Testing
- `swift test --enable-test-discovery` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686dbc4e4afc8320a6a37f876a8372ee