### PR TITLE
Refactor item parameters to stuff

### DIFF
--- a/Bestuff/AddStuffButton.swift
+++ b/Bestuff/AddStuffButton.swift
@@ -15,7 +15,7 @@ struct AddStuffButton: View {
         Button {
             isPresented = true
         } label: {
-            Label("Add Item", systemImage: "plus")
+            Label("Add Stuff", systemImage: "plus")
         }
         .sheet(isPresented: $isPresented) {
             StuffFormView()

--- a/Bestuff/DebugView.swift
+++ b/Bestuff/DebugView.swift
@@ -37,20 +37,20 @@ struct DebugView: View {
             Button("Cancel", role: .cancel) {}
             Button("Create") { createSampleData() }
         } message: {
-            Text("This will add example items to the list.")
+            Text("This will add example stuff to the list.")
         }
         .navigationTitle(Text("Debug"))
     }
 
     private func createSampleData() {
         withAnimation {
-            for item in SampleData.items {
+            for stuff in SampleData.stuffs {
                 _ = try? CreateStuffIntent.perform(
                     (
                         context: modelContext,
-                        title: item.title,
-                        category: item.category,
-                        note: item.note
+                        title: stuff.title,
+                        category: stuff.category,
+                        note: stuff.note
                     )
                 )
             }
@@ -59,13 +59,13 @@ struct DebugView: View {
 }
 
 struct SampleData {
-    struct Item {
+    struct StuffData {
         let title: String
         let category: String
         let note: String?
     }
 
-    static let items: [Item] = [
+    static let stuffs: [StuffData] = [
         .init(title: "Coffee Beans", category: "Groceries", note: "Order from the local roastery."),
         .init(title: "Running Shoes", category: "Fitness", note: "Replace the worn-out pair."),
         .init(title: "Conference Tickets", category: "Work", note: "WWDC 2025"),

--- a/Bestuff/Intents/Stuff/PredictStuffIntent.swift
+++ b/Bestuff/Intents/Stuff/PredictStuffIntent.swift
@@ -39,7 +39,7 @@ struct PredictStuffIntent: AppIntent, IntentPerformer {
 
     private static func generatePrediction(from text: String) async throws -> StuffEntity {
         let prompt = """
-            Based on the following user speech, guess a title, category, optional note and a score from 0 to 100 for an item the user might want to create.
+            Based on the following user speech, guess a title, category, optional note and a score from 0 to 100 for stuff the user might want to create.
             Speech: \(text)
             """
         let session = LanguageModelSession()

--- a/Bestuff/StuffFormView.swift
+++ b/Bestuff/StuffFormView.swift
@@ -25,7 +25,7 @@ struct StuffFormView: View {
                     TextField("Note", text: $note)
                 }
             }
-            .navigationTitle(Text("Add Item"))
+            .navigationTitle(Text("Add Stuff"))
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }

--- a/Bestuff/StuffListView.swift
+++ b/Bestuff/StuffListView.swift
@@ -17,16 +17,16 @@ struct StuffListView: View {
     var body: some View {
         NavigationStack {
             List {
-                ForEach(filteredItems) { item in
-                    NavigationLink(value: item) {
-                        StuffRowView(stuff: item)
+                ForEach(filteredStuffs) { stuff in
+                    NavigationLink(value: stuff) {
+                        StuffRowView(stuff: stuff)
                     }
                 }
                 .onDelete(perform: delete)
             }
             .searchable(text: $searchText)
-            .navigationDestination(for: Stuff.self) { item in
-                StuffDetailView(stuff: item)
+            .navigationDestination(for: Stuff.self) { stuff in
+                StuffDetailView(stuff: stuff)
             }
             .navigationTitle(Text("Best Stuff"))
             .toolbar {
@@ -43,7 +43,7 @@ struct StuffListView: View {
         }
     }
 
-    private var filteredItems: [Stuff] {
+    private var filteredStuffs: [Stuff] {
         if searchText.isEmpty {
             stuffs
         } else {

--- a/BestuffTests/CreateStuffIntentTests.swift
+++ b/BestuffTests/CreateStuffIntentTests.swift
@@ -14,8 +14,8 @@ struct CreateStuffIntentTests {
         let _ = try CreateStuffIntent.perform(
             (context: context, title: "Title", category: "General", note: nil)
         )
-        let items = try context.fetch(FetchDescriptor<Stuff>())
-        #expect(items.count == 1)
-        #expect(items.first?.title == "Title")
+        let stuffs = try context.fetch(FetchDescriptor<Stuff>())
+        #expect(stuffs.count == 1)
+        #expect(stuffs.first?.title == "Title")
     }
 }

--- a/BestuffTests/DeleteStuffIntentTests.swift
+++ b/BestuffTests/DeleteStuffIntentTests.swift
@@ -16,7 +16,7 @@ struct DeleteStuffIntentTests {
         )
         #expect(try context.fetch(FetchDescriptor<Stuff>()).count == 1)
         try DeleteStuffIntent.perform(model)
-        let items = try context.fetch(FetchDescriptor<Stuff>())
-        #expect(items.isEmpty)
+        let stuffs = try context.fetch(FetchDescriptor<Stuff>())
+        #expect(stuffs.isEmpty)
     }
 }


### PR DESCRIPTION
## Summary
- replace "Add Item" strings with "Add Stuff"
- rename item parameters and collections to use stuff naming
- update DebugView sample data terminology
- adjust tests for stuff naming

## Testing
- `swiftlint` *(fails: cannot execute binary file)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686dcec8b7a88320bc7d584fbab2ee6d