### PR TITLE
Add Predict Stuff UI and locale prompt

### DIFF
--- a/Bestuff/Sources/Stuff/Components/PredictStuffButton.swift
+++ b/Bestuff/Sources/Stuff/Components/PredictStuffButton.swift
@@ -1,0 +1,22 @@
+import SwiftData
+import SwiftUI
+
+struct PredictStuffButton: View {
+    @State private var isPresented = false
+
+    var body: some View {
+        Button {
+            isPresented = true
+        } label: {
+            Label("Predict Stuff", systemImage: "wand.and.stars")
+        }
+        .sheet(isPresented: $isPresented) {
+            PredictStuffFormView()
+        }
+    }
+}
+
+#Preview {
+    PredictStuffButton()
+        .modelContainer(for: Stuff.self, inMemory: true)
+}

--- a/Bestuff/Sources/Stuff/Intents/PredictStuffIntent.swift
+++ b/Bestuff/Sources/Stuff/Intents/PredictStuffIntent.swift
@@ -1,4 +1,5 @@
 import AppIntents
+import Foundation
 import FoundationModels
 import SwiftData
 import SwiftUtilities
@@ -38,8 +39,9 @@ struct PredictStuffIntent: AppIntent, IntentPerformer {
     }
 
     private static func generatePrediction(from text: String) async throws -> StuffEntity {
+        let language = Locale.current.language.languageCode?.identifier ?? Locale.current.identifier
         let prompt = """
-            Based on the following user speech, guess a title, category, optional note and a score from 0 to 100 for stuff the user might want to create.
+            Based on the following user speech, guess a title, category, optional note and a score from 0 to 100 for stuff the user might want to create. Respond in \(language).
             Speech: \(text)
             """
         let session = LanguageModelSession()

--- a/Bestuff/Sources/Stuff/Views/PredictStuffFormView.swift
+++ b/Bestuff/Sources/Stuff/Views/PredictStuffFormView.swift
@@ -1,0 +1,54 @@
+import SwiftData
+import SwiftUI
+
+struct PredictStuffFormView: View {
+    @Environment(\.dismiss)
+    private var dismiss
+    @Environment(\.modelContext)
+    private var modelContext
+
+    @State private var speech = ""
+    @State private var isProcessing = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Speech") {
+                    TextField("Speech", text: $speech, axis: .vertical)
+                }
+            }
+            .navigationTitle(Text("Predict Stuff"))
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    if isProcessing {
+                        ProgressView()
+                    } else {
+                        Button("Predict") {
+                            predict()
+                        }
+                        .disabled(speech.isEmpty)
+                    }
+                }
+            }
+        }
+    }
+
+    private func predict() {
+        isProcessing = true
+        Task {
+            _ = try? await PredictStuffIntent.perform((context: modelContext, speech: speech))
+            isProcessing = false
+            dismiss()
+        }
+    }
+}
+
+#Preview {
+    PredictStuffFormView()
+        .modelContainer(for: Stuff.self, inMemory: true)
+}

--- a/Bestuff/Sources/Stuff/Views/StuffListView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffListView.swift
@@ -35,6 +35,7 @@ struct StuffListView: View {
             .navigationTitle(Text("Best Stuff"))
             .toolbar {
                 AddStuffButton()
+                PredictStuffButton()
                 Button {
                     isSettingsPresented = true
                 } label: {


### PR DESCRIPTION
## Summary
- add `PredictStuffButton` component
- implement `PredictStuffFormView` to call `PredictStuffIntent`
- show the new button in `StuffListView`
- specify device language in prediction prompt

## Testing
- `pre-commit run --files Bestuff/Sources/Stuff/Intents/PredictStuffIntent.swift` *(fails: command not found)*
- `swift test` *(fails: could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686de5bceea88320bef952a6b11ad640