### PR TITLE
Add speech recognition to PredictStuff form

### DIFF
--- a/Bestuff/Sources/Stuff/Models/SpeechRecognizer.swift
+++ b/Bestuff/Sources/Stuff/Models/SpeechRecognizer.swift
@@ -1,0 +1,99 @@
+//
+//  SpeechRecognizer.swift
+//  Bestuff
+//
+//  Created by Codex on 2025/07/09.
+//
+
+import AVFoundation
+import Observation
+import Speech
+import SwiftUI
+
+@Observable
+final class SpeechRecognizer {
+    private(set) var transcript = ""
+    private(set) var isTranscribing = false
+
+    private var audioEngine: AVAudioEngine?
+    private var recognitionTask: SFSpeechRecognitionTask?
+    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+
+    func startTranscribing() async throws {
+        guard !isTranscribing else {
+            return
+        }
+        guard await requestAuthorization() else {
+            return
+        }
+
+        audioEngine = .init()
+        guard let audioEngine else {
+            return
+        }
+
+        let audioSession = AVAudioSession.sharedInstance()
+        try audioSession.setCategory(.record, mode: .measurement, options: .duckOthers)
+        try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+
+        recognitionRequest = .init()
+        guard let recognitionRequest else {
+            return
+        }
+        recognitionRequest.shouldReportPartialResults = true
+
+        isTranscribing = true
+        recognitionTask = SFSpeechRecognizer()?.recognitionTask(
+            with: recognitionRequest
+        ) { [weak self] result, error in
+            guard let self else {
+                return
+            }
+            if let result {
+                transcript = result.bestTranscription.formattedString
+                if result.isFinal {
+                    stopTranscribing()
+                }
+            }
+            if error != nil {
+                stopTranscribing()
+            }
+        }
+
+        let inputNode = audioEngine.inputNode
+        let format = inputNode.outputFormat(forBus: 0)
+        inputNode.installTap(
+            onBus: 0,
+            bufferSize: 1024,
+            format: format
+        ) { [weak self] buffer, _ in
+            self?.recognitionRequest?.append(buffer)
+        }
+
+        audioEngine.prepare()
+        try audioEngine.start()
+    }
+
+    func stopTranscribing() {
+        guard isTranscribing else {
+            return
+        }
+        audioEngine?.stop()
+        recognitionRequest?.endAudio()
+        recognitionTask?.cancel()
+        recognitionTask = nil
+        isTranscribing = false
+    }
+
+    private func requestAuthorization() async -> Bool {
+        if SFSpeechRecognizer.authorizationStatus() == .authorized {
+            return true
+        }
+        return await withCheckedContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { status in
+                continuation.resume(returning: status == .authorized)
+            }
+        }
+    }
+}
+

--- a/Bestuff/Sources/Stuff/Views/PredictStuffFormView.swift
+++ b/Bestuff/Sources/Stuff/Views/PredictStuffFormView.swift
@@ -7,6 +7,8 @@ struct PredictStuffFormView: View {
     @Environment(\.modelContext)
     private var modelContext
 
+    @State private var speechRecognizer = SpeechRecognizer()
+
     @State private var speech = ""
     @State private var isProcessing = false
 
@@ -14,7 +16,25 @@ struct PredictStuffFormView: View {
         NavigationStack {
             Form {
                 Section("Speech") {
-                    TextField("Speech", text: $speech, axis: .vertical)
+                    TextEditor(text: $speech)
+                        .frame(minHeight: 120, alignment: .topLeading)
+                        .onChange(of: speechRecognizer.transcript) { newValue in
+                            speech = newValue
+                        }
+                    Button {
+                        if speechRecognizer.isTranscribing {
+                            speechRecognizer.stopTranscribing()
+                        } else {
+                            Task {
+                                try? await speechRecognizer.startTranscribing()
+                            }
+                        }
+                    } label: {
+                        Label(
+                            speechRecognizer.isTranscribing ? "Stop Recording" : "Record",
+                            systemImage: speechRecognizer.isTranscribing ? "stop.circle" : "mic"
+                        )
+                    }
                 }
             }
             .navigationTitle(Text("Predict Stuff"))


### PR DESCRIPTION
## Summary
- enable voice capture with a new `SpeechRecognizer`
- hook `PredictStuffFormView` to start/stop transcribing
- use a large `TextEditor` for predicted speech
- adopt the new `@Observable` macro

## Testing
- `swiftlint --fix --format --strict` *(fails: command not found)*
- `pre-commit run --files Bestuff/Sources/Stuff/Views/PredictStuffFormView.swift Bestuff/Sources/Stuff/Models/SpeechRecognizer.swift` *(fails: command not found)*
- `swift test` *(fails: Package.swift not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e016f4bc0832099b33e73c0ed3a2d