### PR TITLE
Expand debug and settings features

### DIFF
--- a/Bestuff/Sources/BestuffApp.swift
+++ b/Bestuff/Sources/BestuffApp.swift
@@ -10,23 +10,25 @@ import SwiftUI
 
 @main
 struct BestuffApp: App {
-    var sharedModelContainer: ModelContainer = {
-        let schema = Schema([
-            Stuff.self
-        ])
-        let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
+  @AppStorage("isDarkMode") private var isDarkMode = false
+  var sharedModelContainer: ModelContainer = {
+    let schema = Schema([
+      Stuff.self
+    ])
+    let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
 
-        do {
-            return try ModelContainer(for: schema, configurations: [modelConfiguration])
-        } catch {
-            fatalError("Could not create ModelContainer: \(error)")
-        }
-    }()
-
-    var body: some Scene {
-        WindowGroup {
-            ContentView()
-        }
-        .modelContainer(sharedModelContainer)
+    do {
+      return try ModelContainer(for: schema, configurations: [modelConfiguration])
+    } catch {
+      fatalError("Could not create ModelContainer: \(error)")
     }
+  }()
+
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
+        .preferredColorScheme(isDarkMode ? .dark : .light)
+    }
+    .modelContainer(sharedModelContainer)
+  }
 }

--- a/Bestuff/Sources/Settings/Views/SettingsView.swift
+++ b/Bestuff/Sources/Settings/Views/SettingsView.swift
@@ -8,25 +8,40 @@
 import SwiftUI
 
 struct SettingsView: View {
-    var body: some View {
-        NavigationStack {
-            List {
-                Section("General") {
-                    Label("Version 1.0.0", systemImage: "number")
-                }
-                Section("Debug") {
-                    NavigationLink {
-                        DebugView()
-                    } label: {
-                        Text("Debug")
-                    }
-                }
-            }
-            .navigationTitle(Text("Settings"))
+  @AppStorage("isDarkMode") private var isDarkMode = false
+
+  var body: some View {
+    NavigationStack {
+      List {
+        Section("General") {
+          Label("Version 1.0.0", systemImage: "number")
+          Toggle("Dark Mode", isOn: $isDarkMode)
         }
+        Section("Support") {
+          Link(
+            destination: URL(string: "mailto:support@example.com")!
+          ) {
+            Label("Contact Support", systemImage: "envelope")
+          }
+          Link(
+            destination: URL(string: "https://example.com")!
+          ) {
+            Label("Visit Website", systemImage: "safari")
+          }
+        }
+        Section("Debug") {
+          NavigationLink {
+            DebugView()
+          } label: {
+            Text("Debug")
+          }
+        }
+      }
+      .navigationTitle(Text("Settings"))
     }
+  }
 }
 
 #Preview(traits: .sampleData) {
-    SettingsView()
+  SettingsView()
 }

--- a/Bestuff/Sources/Shared/Views/DebugView.swift
+++ b/Bestuff/Sources/Shared/Views/DebugView.swift
@@ -9,71 +9,113 @@ import SwiftData
 import SwiftUI
 
 struct DebugView: View {
-    @Environment(\.modelContext) private var modelContext
-    @State private var isAlertPresented = false
+  @Environment(\.modelContext) private var modelContext
+  @State private var isCreateAlertPresented = false
+  @State private var isClearAlertPresented = false
 
-    var body: some View {
-        List {
-            Section("Information") {
-                HStack {
-                    Text("App Version")
-                    Spacer()
-                    Text("1.0.0")
-                        .foregroundStyle(.secondary)
-                }
-            }
-            Section("Actions") {
-                Button {
-                    isAlertPresented = true
-                } label: {
-                    Text("Create Sample Data")
-                }
-            }
+  var body: some View {
+    List {
+      Section("Information") {
+        HStack {
+          Text("App Version")
+          Spacer()
+          Text("1.0.0")
+            .foregroundStyle(.secondary)
         }
-        .alert(
-            "Create sample data?",
-            isPresented: $isAlertPresented
-        ) {
-            Button("Cancel", role: .cancel) {}
-            Button("Create") { createSampleData() }
-        } message: {
-            Text("This will add example stuff to the list.")
+        HStack {
+          Text("OS Version")
+          Spacer()
+          Text(ProcessInfo.processInfo.operatingSystemVersionString)
+            .foregroundStyle(.secondary)
         }
-        .navigationTitle(Text("Debug"))
+        HStack {
+          Text("Stored Items")
+          Spacer()
+          Text("\(stuffCount)")
+            .foregroundStyle(.secondary)
+        }
+      }
+      Section("Actions") {
+        Button {
+          isCreateAlertPresented = true
+        } label: {
+          Text("Create Sample Data")
+        }
+        Button(role: .destructive) {
+          isClearAlertPresented = true
+        } label: {
+          Text("Clear All Data")
+        }
+      }
     }
+    .alert(
+      "Create sample data?",
+      isPresented: $isCreateAlertPresented
+    ) {
+      Button("Cancel", role: .cancel) {}
+      Button("Create") { createSampleData() }
+    } message: {
+      Text("This will add example stuff to the list.")
+    }
+    .alert(
+      "Clear all data?",
+      isPresented: $isClearAlertPresented
+    ) {
+      Button("Cancel", role: .cancel) {}
+      Button("Clear", role: .destructive) { clearAllData() }
+    } message: {
+      Text("This will permanently delete all stuff.")
+    }
+    .navigationTitle(Text("Debug"))
+  }
 
-    private func createSampleData() {
-        withAnimation {
-            for stuff in SampleData.stuffs {
-                _ = try? CreateStuffIntent.perform(
-                    (
-                        context: modelContext,
-                        title: stuff.title,
-                        category: stuff.category,
-                        note: stuff.note
-                    )
-                )
-            }
-        }
+  private func createSampleData() {
+    withAnimation {
+      for stuff in SampleData.stuffs {
+        _ = try? CreateStuffIntent.perform(
+          (
+            context: modelContext,
+            title: stuff.title,
+            category: stuff.category,
+            note: stuff.note
+          )
+        )
+      }
     }
+  }
+
+  private func clearAllData() {
+    withAnimation {
+      let descriptor: FetchDescriptor<Stuff> = .init()
+      let allStuffs = (try? modelContext.fetch(descriptor)) ?? []
+      for stuff in allStuffs {
+        try? DeleteStuffIntent.perform(stuff)
+      }
+    }
+  }
+
+  private var stuffCount: Int {
+    let descriptor: FetchDescriptor<Stuff> = .init()
+    return (try? modelContext.fetch(descriptor).count) ?? 0
+  }
 }
 
 struct SampleData {
-    struct StuffData {
-        let title: String
-        let category: String
-        let note: String?
-    }
+  struct StuffData {
+    let title: String
+    let category: String
+    let note: String?
+  }
 
-    static let stuffs: [StuffData] = [
-        .init(title: "Coffee Beans", category: "Groceries", note: "Order from the local roastery."),
-        .init(title: "Running Shoes", category: "Fitness", note: "Replace the worn-out pair."),
-        .init(title: "Conference Tickets", category: "Work", note: "WWDC 2025"),
-        .init(title: "Vacation Booking", category: "Travel", note: "Reserve hotel and flights."),
-        .init(title: "Birthday Gift", category: "Personal", note: "Surprise for Alice.")
-    ]
+  static let stuffs: [StuffData] = [
+    .init(title: "Coffee Beans", category: "Groceries", note: "Order from the local roastery."),
+    .init(title: "Running Shoes", category: "Fitness", note: "Replace the worn-out pair."),
+    .init(title: "Conference Tickets", category: "Work", note: "WWDC 2025"),
+    .init(title: "Vacation Booking", category: "Travel", note: "Reserve hotel and flights."),
+    .init(title: "Birthday Gift", category: "Personal", note: "Surprise for Alice."),
+  ]
 }
 
 #Preview(traits: .sampleData) {
-    NavigationStack { DebugView() }
+  NavigationStack { DebugView() }
 }


### PR DESCRIPTION
## Summary
- enrich DebugView with OS version, item count, and a clear data action
- add support links and dark mode toggle in SettingsView
- apply user's color scheme choice throughout the app

## Testing
- `swift test` *(fails: `Package.swift` not found)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e088bec408320aa7c449ed4212919