### PR TITLE
Add Recap page

### DIFF
--- a/Bestuff/Sources/ContentView.swift
+++ b/Bestuff/Sources/ContentView.swift
@@ -12,20 +12,28 @@ struct ContentView: View {
     @State private var selection: Stuff?
 
     var body: some View {
-        NavigationSplitView {
-            StuffListView(selection: $selection)
-        } detail: {
-            if let stuff = selection {
+        TabView {
+            NavigationSplitView {
+                StuffListView(selection: $selection)
+            } detail: {
+                if let stuff = selection {
+                    StuffDetailView()
+                        .environment(stuff)
+                } else {
+                    Text("Select Stuff")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .navigationDestination(for: Stuff.self) { stuff in
                 StuffDetailView()
                     .environment(stuff)
-            } else {
-                Text("Select Stuff")
-                    .foregroundStyle(.secondary)
             }
-        }
-        .navigationDestination(for: Stuff.self) { stuff in
-            StuffDetailView()
-                .environment(stuff)
+            .tabItem { Label("Stuffs", systemImage: "list.bullet") }
+
+            NavigationStack {
+                RecapView()
+            }
+            .tabItem { Label("Recap", systemImage: "calendar") }
         }
     }
 }

--- a/Bestuff/Sources/Stuff/Views/RecapView.swift
+++ b/Bestuff/Sources/Stuff/Views/RecapView.swift
@@ -1,0 +1,81 @@
+import SwiftData
+import SwiftUI
+
+enum RecapPeriod: String, CaseIterable, Identifiable {
+    case monthly
+    case yearly
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .monthly:
+            "Monthly"
+        case .yearly:
+            "Yearly"
+        }
+    }
+}
+
+struct RecapView: View {
+    @Query(sort: \Stuff.createdAt, order: .reverse)
+    private var stuffs: [Stuff]
+    @State private var period: RecapPeriod = .monthly
+
+    var body: some View {
+        List {
+            Picker("Period", selection: $period) {
+                ForEach(RecapPeriod.allCases) { period in
+                    Text(period.title).tag(period)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding(.vertical)
+
+            ForEach(sortedKeys, id: \.self) { date in
+                Section(header: Text(title(for: date))) {
+                    ForEach(groupedStuffs[date] ?? []) { stuff in
+                        StuffRowView()
+                            .environment(stuff)
+                    }
+                }
+            }
+        }
+        .navigationTitle(Text("Recap"))
+    }
+
+    private var groupedStuffs: [Date: [Stuff]] {
+        Dictionary(grouping: stuffs) { model in
+            let calendar = Calendar.current
+            let components: DateComponents
+            switch period {
+            case .monthly:
+                components = calendar.dateComponents([.year, .month], from: model.createdAt)
+            case .yearly:
+                components = calendar.dateComponents([.year], from: model.createdAt)
+            }
+            return calendar.date(from: components) ?? model.createdAt
+        }
+    }
+
+    private var sortedKeys: [Date] {
+        groupedStuffs.keys.sorted(by: >)
+    }
+
+    private func title(for date: Date) -> String {
+        let formatter = DateFormatter()
+        switch period {
+        case .monthly:
+            formatter.dateFormat = "LLLL yyyy"
+        case .yearly:
+            formatter.dateFormat = "yyyy"
+        }
+        return formatter.string(from: date)
+    }
+}
+
+#Preview(traits: .sampleData) {
+    NavigationStack {
+        RecapView()
+    }
+}


### PR DESCRIPTION
## Summary
- create `RecapView` to show monthly or yearly groups of `Stuff`
- turn `ContentView` into a `TabView` with the new Recap screen

## Testing
- `swiftlint --fix --format --strict` *(fails: command not found)*
- `swift test` *(fails: Package.swift not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e0845c4648320876bc0143e373289