### PR TITLE
Add occurrence date and editing

### DIFF
--- a/Bestuff/Sources/Shared/Views/DebugView.swift
+++ b/Bestuff/Sources/Shared/Views/DebugView.swift
@@ -77,7 +77,8 @@ struct DebugView: View {
             context: modelContext,
             title: stuff.title,
             category: stuff.category,
-            note: stuff.note
+            note: stuff.note,
+            occurredAt: .now
           )
         )
       }

--- a/Bestuff/Sources/Stuff/Entities/Stuff.swift
+++ b/Bestuff/Sources/Stuff/Entities/Stuff.swift
@@ -14,6 +14,7 @@ nonisolated final class Stuff {
     var category: String
     var note: String?
     var score: Int
+    var occurredAt: Date
     var createdAt: Date
 
     init(
@@ -21,12 +22,14 @@ nonisolated final class Stuff {
         category: String,
         note: String? = nil,
         score: Int = 0,
+        occurredAt: Date = .now,
         createdAt: Date = .now
     ) {
         self.title = title
         self.category = category
         self.note = note
         self.score = score
+        self.occurredAt = occurredAt
         self.createdAt = createdAt
     }
 }

--- a/Bestuff/Sources/Stuff/Entities/StuffEntity.swift
+++ b/Bestuff/Sources/Stuff/Entities/StuffEntity.swift
@@ -10,6 +10,7 @@ nonisolated struct StuffEntity {
     let category: String
     let note: String?
     let score: Int
+    let occurredAt: Date
 }
 
 extension StuffEntity: AppEntity {
@@ -38,7 +39,8 @@ extension StuffEntity: ModelBridgeable {
             title: model.title,
             category: model.category,
             note: model.note,
-            score: model.score
+            score: model.score,
+            occurredAt: model.occurredAt
         )
     }
 

--- a/Bestuff/Sources/Stuff/Intents/CreateStuffIntent.swift
+++ b/Bestuff/Sources/Stuff/Intents/CreateStuffIntent.swift
@@ -3,7 +3,7 @@ import SwiftData
 import SwiftUtilities
 
 struct CreateStuffIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, title: String, category: String, note: String?)
+    typealias Input = (context: ModelContext, title: String, category: String, note: String?, occurredAt: Date)
     typealias Output = Stuff
 
     nonisolated static var title: LocalizedStringResource {
@@ -19,17 +19,20 @@ struct CreateStuffIntent: AppIntent, IntentPerformer {
     @Parameter(title: "Note")
     private var note: String?
 
+    @Parameter(title: "Date")
+    private var occurredAt: Date
+
     @Dependency private var modelContainer: ModelContainer
 
     static func perform(_ input: Input) throws -> Output {
-        let (context, title, category, note) = input
-        let model = Stuff(title: title, category: category, note: note)
+        let (context, title, category, note, occurredAt) = input
+        let model = Stuff(title: title, category: category, note: note, occurredAt: occurredAt)
         context.insert(model)
         return model
     }
 
     func perform() throws -> some ReturnsValue<StuffEntity> {
-        let model = try Self.perform((context: modelContainer.mainContext, title: title, category: category, note: note))
+        let model = try Self.perform((context: modelContainer.mainContext, title: title, category: category, note: note, occurredAt: occurredAt))
         guard let entity = StuffEntity(model) else {
             throw StuffError.stuffNotFound
         }

--- a/Bestuff/Sources/Stuff/Intents/PredictStuffIntent.swift
+++ b/Bestuff/Sources/Stuff/Intents/PredictStuffIntent.swift
@@ -24,7 +24,8 @@ struct PredictStuffIntent: AppIntent, IntentPerformer {
             title: prediction.title,
             category: prediction.category,
             note: prediction.note,
-            score: prediction.score
+            score: prediction.score,
+            occurredAt: .now
         )
         context.insert(model)
         return model

--- a/Bestuff/Sources/Stuff/Models/StuffEntityQuery.swift
+++ b/Bestuff/Sources/Stuff/Models/StuffEntityQuery.swift
@@ -28,7 +28,7 @@ struct StuffEntityQuery: EntityStringQuery {
 
     func suggestedEntities() throws -> [StuffEntity] {
         var descriptor = FetchDescriptor(
-            sortBy: [SortDescriptor(\Stuff.createdAt, order: .reverse)]
+            sortBy: [SortDescriptor(\Stuff.occurredAt, order: .reverse)]
         )
         descriptor.fetchLimit = 5
         return try modelContainer.mainContext.fetch(

--- a/Bestuff/Sources/Stuff/Views/EditStuffFormView.swift
+++ b/Bestuff/Sources/Stuff/Views/EditStuffFormView.swift
@@ -1,23 +1,30 @@
 //
-//  StuffFormView.swift
+//  EditStuffFormView.swift
 //  Bestuff
 //
-//  Created by Hiromu Nakano on 2025/07/08.
+//  Created by Codex on 2025/07/10.
 //
 
 import SwiftData
 import SwiftUI
 
-struct StuffFormView: View {
+struct EditStuffFormView: View {
     @Environment(\.dismiss)
     private var dismiss
-    @Environment(\.modelContext)
-    private var modelContext
+    @Bindable var stuff: Stuff
 
-    @State private var title = ""
-    @State private var category = ""
-    @State private var note = ""
-    @State private var eventAt = Date()
+    @State private var title: String
+    @State private var category: String
+    @State private var note: String
+    @State private var eventAt: Date
+
+    init(stuff: Stuff) {
+        _stuff = Bindable(wrappedValue: stuff)
+        _title = State(initialValue: stuff.title)
+        _category = State(initialValue: stuff.category)
+        _note = State(initialValue: stuff.note ?? "")
+        _eventAt = State(initialValue: stuff.occurredAt)
+    }
 
     var body: some View {
         NavigationStack {
@@ -29,7 +36,7 @@ struct StuffFormView: View {
                     DatePicker("Date", selection: $eventAt, displayedComponents: .date)
                 }
             }
-            .navigationTitle(Text("Add Stuff"))
+            .navigationTitle(Text("Edit Stuff"))
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
@@ -46,20 +53,17 @@ struct StuffFormView: View {
 
     private func save() {
         withAnimation {
-            _ = try? CreateStuffIntent.perform(
-                (
-                    context: modelContext,
-                    title: title,
-                    category: category,
-                    note: note.isEmpty ? nil : note,
-                    occurredAt: eventAt
-                )
-            )
+            stuff.title = title
+            stuff.category = category
+            stuff.note = note.isEmpty ? nil : note
+            stuff.occurredAt = eventAt
             dismiss()
         }
     }
 }
 
 #Preview(traits: .sampleData) {
-    StuffFormView()
+    EditStuffFormView(
+        stuff: .init(title: "Sample", category: "General")
+    )
 }

--- a/Bestuff/Sources/Stuff/Views/RecapView.swift
+++ b/Bestuff/Sources/Stuff/Views/RecapView.swift
@@ -18,7 +18,7 @@ enum RecapPeriod: String, CaseIterable, Identifiable {
 }
 
 struct RecapView: View {
-    @Query(sort: \Stuff.createdAt, order: .reverse)
+    @Query(sort: \Stuff.occurredAt, order: .reverse)
     private var stuffs: [Stuff]
     @State private var period: RecapPeriod = .monthly
 
@@ -50,11 +50,11 @@ struct RecapView: View {
             let components: DateComponents
             switch period {
             case .monthly:
-                components = calendar.dateComponents([.year, .month], from: model.createdAt)
+                components = calendar.dateComponents([.year, .month], from: model.occurredAt)
             case .yearly:
-                components = calendar.dateComponents([.year], from: model.createdAt)
+                components = calendar.dateComponents([.year], from: model.occurredAt)
             }
-            return calendar.date(from: components) ?? model.createdAt
+            return calendar.date(from: components) ?? model.occurredAt
         }
     }
 

--- a/Bestuff/Sources/Stuff/Views/StuffDetailView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffDetailView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct StuffDetailView: View {
     @Environment(Stuff.self)
     private var stuff
+    @State private var isEditPresented = false
 
     var body: some View {
         ScrollView {
@@ -24,6 +25,9 @@ struct StuffDetailView: View {
                 }
                 Text("Score: \(stuff.score)")
                     .font(.headline)
+                Text("Date \(stuff.occurredAt.formatted(.dateTime))")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
                 Text("Created \(stuff.createdAt.formatted(.dateTime))")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
@@ -50,6 +54,10 @@ struct StuffDetailView: View {
         .navigationTitle(Text(stuff.title))
         .toolbar {
             ShareLink(item: description)
+            Button("Edit") { isEditPresented = true }
+        }
+        .sheet(isPresented: $isEditPresented) {
+            EditStuffFormView(stuff: stuff)
         }
     }
 
@@ -72,6 +80,7 @@ struct StuffDetailView: View {
                     category: "General",
                     note: "Notes",
                     score: 80,
+                    occurredAt: .now,
                     createdAt: .now
                 )
             )

--- a/Bestuff/Sources/Stuff/Views/StuffListView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffListView.swift
@@ -12,7 +12,7 @@ struct StuffListView: View {
     @Binding var selection: Stuff?
     @Environment(\.modelContext)
     private var modelContext
-    @Query(sort: \Stuff.createdAt, order: .reverse)
+    @Query(sort: \Stuff.occurredAt, order: .reverse)
     private var stuffs: [Stuff]
     @State private var searchText = ""
     @State private var isSettingsPresented = false

--- a/BestuffTests/CreateStuffIntentTests.swift
+++ b/BestuffTests/CreateStuffIntentTests.swift
@@ -12,7 +12,7 @@ struct CreateStuffIntentTests {
 
     @Test func perform() throws {
         let _ = try CreateStuffIntent.perform(
-            (context: context, title: "Title", category: "General", note: nil)
+            (context: context, title: "Title", category: "General", note: nil, occurredAt: .now)
         )
         let stuffs = try context.fetch(FetchDescriptor<Stuff>())
         #expect(stuffs.count == 1)

--- a/BestuffTests/DeleteStuffIntentTests.swift
+++ b/BestuffTests/DeleteStuffIntentTests.swift
@@ -12,7 +12,7 @@ struct DeleteStuffIntentTests {
 
     @Test func perform() throws {
         let model = try CreateStuffIntent.perform(
-            (context: context, title: "Title", category: "General", note: nil)
+            (context: context, title: "Title", category: "General", note: nil, occurredAt: .now)
         )
         #expect(try context.fetch(FetchDescriptor<Stuff>()).count == 1)
         try DeleteStuffIntent.perform(model)


### PR DESCRIPTION
## Summary
- track when each item occurred in `Stuff`
- store the date in `StuffEntity`
- edit items via new `EditStuffFormView`
- group recaps by the occurred date
- update forms, intents, views, and tests for the new field

## Testing
- `swiftlint` *(fails: cannot execute binary file)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686e3b72b3a88320ae74b09c4bad7835