### PR TITLE
Update tab views to use NavigationSplitView

### DIFF
--- a/Bestuff/Sources/ContentView.swift
+++ b/Bestuff/Sources/ContentView.swift
@@ -35,7 +35,9 @@ struct ContentView: View {
             }
 
             Tab {
-                NavigationStack {
+                NavigationSplitView {
+                    EmptyView()
+                } detail: {
                     RecapView()
                 }
             } label: {
@@ -43,7 +45,9 @@ struct ContentView: View {
             }
 
             Tab {
-                NavigationStack {
+                NavigationSplitView {
+                    EmptyView()
+                } detail: {
                     PlanView()
                 }
             } label: {
@@ -51,8 +55,20 @@ struct ContentView: View {
             }
 
             Tab(role: .search) {
-                NavigationStack {
+                NavigationSplitView {
                     StuffListView(selection: $selection)
+                } detail: {
+                    if let stuff = selection {
+                        StuffDetailView()
+                            .environment(stuff)
+                    } else {
+                        Text("Select Stuff")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .navigationDestination(for: Stuff.self) { stuff in
+                    StuffDetailView()
+                        .environment(stuff)
                 }
             } label: {
                 Label("Search", systemImage: "magnifyingglass")


### PR DESCRIPTION
## Summary
- replace `NavigationStack` with `NavigationSplitView` in Recap, Plan and Search tabs
- keep a placeholder sidebar for tabs without list content

## Testing
- `swift test` *(fails: `Could not find Package.swift`)*
- `swiftlint` *(fails: `libsourcekitdInProc.so` missing)*

------
https://chatgpt.com/codex/tasks/task_e_686f1546c1b883209fa8516f2dd33b27