### PR TITLE
Refactor Recap tab with NavigationSplitView

### DIFF
--- a/Bestuff/Sources/ContentView.swift
+++ b/Bestuff/Sources/ContentView.swift
@@ -35,11 +35,7 @@ struct ContentView: View {
             }
 
             Tab {
-                NavigationSplitView {
-                    EmptyView()
-                } detail: {
-                    RecapView()
-                }
+                RecapView()
             } label: {
                 Label("Recap", systemImage: "calendar")
             }

--- a/Bestuff/Sources/Stuff/Views/RecapDetailView.swift
+++ b/Bestuff/Sources/Stuff/Views/RecapDetailView.swift
@@ -1,0 +1,43 @@
+//
+//  RecapDetailView.swift
+//  Bestuff
+//
+//  Created by Codex on 2025/07/22.
+//
+
+import SwiftUI
+
+struct RecapDetailView: View {
+    let date: Date
+    let period: RecapPeriod
+    let stuffs: [Stuff]
+
+    var body: some View {
+        List(stuffs) { stuff in
+            NavigationLink(value: stuff) {
+                StuffRowView()
+                    .environment(stuff)
+            }
+        }
+        .navigationTitle(Text(title(for: date)))
+    }
+
+    private func title(for date: Date) -> String {
+        let formatter = DateFormatter()
+        switch period {
+        case .monthly:
+            formatter.dateFormat = "LLLL yyyy"
+        case .yearly:
+            formatter.dateFormat = "yyyy"
+        }
+        return formatter.string(from: date)
+    }
+}
+
+#Preview(traits: .sampleData) {
+    RecapDetailView(
+        date: .now,
+        period: .monthly,
+        stuffs: []
+    )
+}


### PR DESCRIPTION
## Summary
- rework `RecapView` to use `NavigationSplitView`
- add new `RecapDetailView` for selected period
- show `RecapView` directly from `ContentView` tab

## Testing
- `pre-commit` *(fails: git fetch 403)*
- `swiftlint` *(fails: libsourcekitdInProc.so not found)*
- `swift test` *(fails: Package.swift missing)*

------
https://chatgpt.com/codex/tasks/task_e_686f1a5dbe9c8320ae95b349b3ac35bb