### PR TITLE
Add close button for Settings sheet

### DIFF
--- a/Bestuff/Sources/Settings/Views/SettingsView.swift
+++ b/Bestuff/Sources/Settings/Views/SettingsView.swift
@@ -13,6 +13,8 @@ enum SettingsTab: Hashable {
 }
 
 struct SettingsView: View {
+    @Environment(\.dismiss)
+    private var dismiss
     @AppStorage("isDarkMode") private var isDarkMode = false
     @State private var selection: SettingsTab = .general
 
@@ -39,11 +41,27 @@ struct SettingsView: View {
                         }
                     }
                     .navigationTitle(Text("Settings"))
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Close", systemImage: "xmark") {
+                                Logger(#file).info("Settings closed")
+                                dismiss()
+                            }
+                        }
+                    }
                 }
             }
             Tab("Debug", systemImage: "ladybug", value: SettingsTab.debug) {
                 NavigationStack {
                     DebugView()
+                        .toolbar {
+                            ToolbarItem(placement: .cancellationAction) {
+                                Button("Close", systemImage: "xmark") {
+                                    Logger(#file).info("Settings closed")
+                                    dismiss()
+                                }
+                            }
+                        }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add dismiss handling to SettingsView
- provide a `Close` button in both tabs of Settings

## Testing
- `xcodebuild test -project Bestuff.xcodeproj -scheme Bestuff -destination 'platform=iOS Simulator,name=iPhone 15 Pro'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f1e923ecc8320bea38e227073f8e5