### PR TITLE
Refactor Plan tab with NavigationSplitView

### DIFF
--- a/Bestuff/Sources/ContentView.swift
+++ b/Bestuff/Sources/ContentView.swift
@@ -41,11 +41,7 @@ struct ContentView: View {
             }
 
             Tab {
-                NavigationSplitView {
-                    EmptyView()
-                } detail: {
-                    PlanView()
-                }
+                PlanView()
             } label: {
                 Label("Plan", systemImage: "lightbulb")
             }

--- a/Bestuff/Sources/Stuff/Views/PlanDetailView.swift
+++ b/Bestuff/Sources/Stuff/Views/PlanDetailView.swift
@@ -1,0 +1,25 @@
+//
+//  PlanDetailView.swift
+//  Bestuff
+//
+//  Created by Codex on 2025/07/30.
+//
+
+import SwiftUI
+
+struct PlanDetailView: View {
+    let suggestion: String
+
+    var body: some View {
+        ScrollView {
+            Text(suggestion)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+        }
+        .navigationTitle(Text("Suggestion"))
+    }
+}
+
+#Preview(traits: .sampleData) {
+    PlanDetailView(suggestion: "Sample suggestion")
+}

--- a/Bestuff/Sources/Stuff/Views/PlanView.swift
+++ b/Bestuff/Sources/Stuff/Views/PlanView.swift
@@ -13,39 +13,55 @@ struct PlanView: View {
     @State private var suggestions: [String] = []
     @State private var period: PlanPeriod = .nextMonth
     @State private var isProcessing = false
+    @State private var selection: String?
 
     var body: some View {
-        List {
-            Picker("Period", selection: $period) {
-                ForEach(PlanPeriod.allCases) { period in
-                    Text(period.title).tag(period)
+        NavigationSplitView {
+            List(selection: $selection) {
+                Picker("Period", selection: $period) {
+                    ForEach(PlanPeriod.allCases) { period in
+                        Text(period.title).tag(period)
+                    }
                 }
-            }
-            .pickerStyle(.segmented)
-            .padding(.vertical)
+                .pickerStyle(.segmented)
+                .padding(.vertical)
 
-            if suggestions.isEmpty {
-                Text("No suggestions yet")
-                    .foregroundStyle(.secondary)
-            } else {
-                Section("Suggestions") {
-                    ForEach(suggestions, id: \.self) { suggestion in
-                        Text(suggestion)
+                if suggestions.isEmpty {
+                    Text("No suggestions yet")
+                        .foregroundStyle(.secondary)
+                } else {
+                    Section("Suggestions") {
+                        ForEach(suggestions, id: \.self) { suggestion in
+                            NavigationLink(value: suggestion) {
+                                Text(suggestion)
+                                    .lineLimit(1)
+                            }
+                        }
                     }
                 }
             }
-        }
-        .navigationTitle(Text("Plan"))
-        .toolbar {
-            ToolbarItem(placement: .confirmationAction) {
-                if isProcessing {
-                    ProgressView()
-                } else {
-                    Button("Generate", systemImage: "sparkles", action: generate)
-                    .buttonStyle(.borderedProminent)
-                    .tint(.accentColor)
+            .navigationTitle(Text("Plan"))
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    if isProcessing {
+                        ProgressView()
+                    } else {
+                        Button("Generate", systemImage: "sparkles", action: generate)
+                            .buttonStyle(.borderedProminent)
+                            .tint(.accentColor)
+                    }
                 }
             }
+        } detail: {
+            if let suggestion = selection {
+                PlanDetailView(suggestion: suggestion)
+            } else {
+                Text("Select Suggestion")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .navigationDestination(for: String.self) { suggestion in
+            PlanDetailView(suggestion: suggestion)
         }
     }
 
@@ -64,7 +80,5 @@ struct PlanView: View {
 }
 
 #Preview(traits: .sampleData) {
-    NavigationStack {
-        PlanView()
-    }
+    PlanView()
 }


### PR DESCRIPTION
## Summary
- rework PlanView as a `NavigationSplitView` with a selectable list of suggestions
- add `PlanDetailView` to show the selected suggestion
- simplify ContentView so the Plan tab directly presents `PlanView`

## Testing
- `swiftlint --fix --format --strict` *(fails: cannot execute binary file)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686f1ecf88e083208a65a319c2c22c7c