### PR TITLE
Fix Recap view navigation to stuff detail

### DIFF
--- a/Bestuff/Sources/Stuff/Views/RecapDetailView.swift
+++ b/Bestuff/Sources/Stuff/Views/RecapDetailView.swift
@@ -11,9 +11,10 @@ struct RecapDetailView: View {
     let date: Date
     let period: RecapPeriod
     let stuffs: [Stuff]
+    @Binding var selection: Stuff?
 
     var body: some View {
-        List(stuffs) { stuff in
+        List(stuffs, selection: $selection) { stuff in
             NavigationLink(value: stuff) {
                 StuffRowView()
                     .environment(stuff)
@@ -38,6 +39,7 @@ struct RecapDetailView: View {
     RecapDetailView(
         date: .now,
         period: .monthly,
-        stuffs: []
+        stuffs: [],
+        selection: .constant(nil)
     )
 }

--- a/Bestuff/Sources/Stuff/Views/RecapView.swift
+++ b/Bestuff/Sources/Stuff/Views/RecapView.swift
@@ -43,11 +43,15 @@ struct RecapView: View {
             }
             .navigationTitle(Text("Recap"))
         } detail: {
-            if let date = selection {
+            if let stuff = stuffSelection {
+                StuffDetailView()
+                    .environment(stuff)
+            } else if let date = selection {
                 RecapDetailView(
                     date: date,
                     period: period,
-                    stuffs: groupedStuffs[date] ?? []
+                    stuffs: groupedStuffs[date] ?? [],
+                    selection: $stuffSelection
                 )
                 .navigationTitle(Text(title(for: date)))
             } else {
@@ -59,7 +63,8 @@ struct RecapView: View {
             RecapDetailView(
                 date: date,
                 period: period,
-                stuffs: groupedStuffs[date] ?? []
+                stuffs: groupedStuffs[date] ?? [],
+                selection: $stuffSelection
             )
         }
         .navigationDestination(for: Stuff.self) { stuff in


### PR DESCRIPTION
## Summary
- update `RecapDetailView` to allow item selection
- show `StuffDetailView` when a stuff row is tapped from Recap

## Testing
- `pre-commit run --files Bestuff/Sources/Stuff/Views/RecapView.swift Bestuff/Sources/Stuff/Views/RecapDetailView.swift` *(fails: RPC failed; HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_686f1f16592c8320b1f14deac304a9ac