### PR TITLE
Add device info in debug screen

### DIFF
--- a/Bestuff/Sources/Shared/Views/DebugView.swift
+++ b/Bestuff/Sources/Shared/Views/DebugView.swift
@@ -29,6 +29,30 @@ struct DebugView: View {
                         .foregroundStyle(.secondary)
                 }
                 HStack {
+                    Text("Language")
+                    Spacer()
+                    Text(Locale.current.language.languageCode?.identifier ?? Locale.current.identifier)
+                        .foregroundStyle(.secondary)
+                }
+                HStack {
+                    Text("Region")
+                    Spacer()
+                    Text(Locale.current.region?.identifier ?? "-")
+                        .foregroundStyle(.secondary)
+                }
+                HStack {
+                    Text("Time Zone")
+                    Spacer()
+                    Text(TimeZone.current.identifier)
+                        .foregroundStyle(.secondary)
+                }
+                HStack {
+                    Text("Calendar")
+                    Spacer()
+                    Text(Calendar.current.identifier)
+                        .foregroundStyle(.secondary)
+                }
+                HStack {
                     Text("Stored Items")
                     Spacer()
                     Text("\(stuffCount)")


### PR DESCRIPTION
## Summary
- display the user's language, region, time zone and calendar in DebugView

## Testing
- `swiftlint --fix --format --strict` *(fails: Loading libsourcekitdInProc.so failed)*
- `pre-commit run --files Bestuff/Sources/Shared/Views/DebugView.swift` *(fails: cannot fetch SwiftLint repo)*
- `xcodebuild -list -project Bestuff.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f25cf132883208c33fb6d94ff7e7e