### PR TITLE
Fix Recap navigation reset

### DIFF
--- a/Bestuff/Sources/Stuff/Views/RecapView.swift
+++ b/Bestuff/Sources/Stuff/Views/RecapView.swift
@@ -71,6 +71,15 @@ struct RecapView: View {
             StuffDetailView()
                 .environment(stuff)
         }
+        .onDisappear {
+            selection = nil
+            stuffSelection = nil
+        }
+        .onChange(of: selection) { _, newValue in
+            if newValue == nil {
+                stuffSelection = nil
+            }
+        }
     }
 
     private var groupedStuffs: [Date: [Stuff]] {


### PR DESCRIPTION
## Summary
- reset `RecapView` selections when leaving the view

## Testing
- `apt-get update`
- `apt-get install` failed to locate `swiftlint`
- `swift build` failed because `Package.swift` is missing

------
https://chatgpt.com/codex/tasks/task_e_686f26f7ab988320a4e4688a3fa4354f