### PR TITLE
Restructure Recap to three-column split view

### DIFF
--- a/Bestuff/Sources/Stuff/Views/RecapView.swift
+++ b/Bestuff/Sources/Stuff/Views/RecapView.swift
@@ -42,20 +42,24 @@ struct RecapView: View {
                 }
             }
             .navigationTitle(Text("Recap"))
-        } detail: {
-            if let stuff = stuffSelection {
-                StuffDetailView()
-                    .environment(stuff)
-            } else if let date = selection {
+        } content: {
+            if let date = selection {
                 RecapDetailView(
                     date: date,
                     period: period,
                     stuffs: groupedStuffs[date] ?? [],
                     selection: $stuffSelection
                 )
-                .navigationTitle(Text(title(for: date)))
             } else {
                 Text("Select Period")
+                    .foregroundStyle(.secondary)
+            }
+        } detail: {
+            if let stuff = stuffSelection {
+                StuffDetailView()
+                    .environment(stuff)
+            } else {
+                Text("Select Stuff")
                     .foregroundStyle(.secondary)
             }
         }


### PR DESCRIPTION
## Summary
- show Recap detail in `NavigationSplitView`'s middle column
- show Stuff detail in the split view's right column

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_686f3a2cc0b48320aa02f7b494675339