### PR TITLE
Refine StuffDetailView design

### DIFF
--- a/Bestuff/Sources/Stuff/Views/StuffDetailView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffDetailView.swift
@@ -34,27 +34,25 @@ struct StuffDetailView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding()
-            .background(
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .fill(.ultraThinMaterial)
+            .background(.thinMaterial)
+            .clipShape(
+                .init(cornerRadius: 16, style: .continuous)
             )
+            .glassEffect()
             .padding()
         }
-        .background(
-            LinearGradient(
-                colors: [
-                    .blue.opacity(0.3),
-                    .purple.opacity(0.3)
-                ],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            )
-            .ignoresSafeArea()
-        )
         .navigationTitle(Text(stuff.title))
         .toolbar {
-            ShareLink(item: description)
-            Button("Edit", systemImage: "pencil") { isEditing = true }
+            ToolbarItemGroup(placement: .primaryAction) {
+                ShareLink(item: description)
+            }
+
+            ToolbarSpacer(.fixed, placement: .primaryAction)
+
+            ToolbarItem(placement: .primaryAction) {
+                Button("Edit", systemImage: "pencil") { isEditing = true }
+                    .buttonStyle(.borderedProminent)
+            }
         }
         .sheet(isPresented: $isEditing) {
             StuffFormView(stuff: stuff)

--- a/Bestuff/Sources/Stuff/Views/StuffDetailView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffDetailView.swift
@@ -36,7 +36,7 @@ struct StuffDetailView: View {
             .padding()
             .background(.thinMaterial)
             .clipShape(
-                .init(cornerRadius: 16, style: .continuous)
+                Capsule(style: .continuous)
             )
             .glassEffect()
             .padding()


### PR DESCRIPTION
## Summary
- simplify StuffDetailView appearance
- apply a liquid-like glass effect
- use toolbar spacer and tint

## Testing
- `pre-commit run --files Bestuff/Sources/Stuff/Views/StuffDetailView.swift` *(fails: Could not fetch SwiftLint)*
- `swiftlint --fix --format --strict Bestuff/Sources/Stuff/Views/StuffDetailView.swift` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f3d082b04832082e8e229de3a6afe