### PR TITLE
Add CloseButton to modal screens

### DIFF
--- a/Bestuff/Sources/Settings/Views/SettingsView.swift
+++ b/Bestuff/Sources/Settings/Views/SettingsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import SwiftUtilities
 
 enum SettingsTab: Hashable {
     case general
@@ -13,8 +14,6 @@ enum SettingsTab: Hashable {
 }
 
 struct SettingsView: View {
-    @Environment(\.dismiss)
-    private var dismiss
     @AppStorage("isDarkMode") private var isDarkMode = false
     @State private var selection: SettingsTab = .general
 
@@ -43,10 +42,7 @@ struct SettingsView: View {
                     .navigationTitle(Text("Settings"))
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
-                            Button("Close", systemImage: "xmark") {
-                                Logger(#file).info("Settings closed")
-                                dismiss()
-                            }
+                            CloseButton()
                         }
                     }
                 }
@@ -56,10 +52,7 @@ struct SettingsView: View {
                     DebugView()
                         .toolbar {
                             ToolbarItem(placement: .cancellationAction) {
-                                Button("Close", systemImage: "xmark") {
-                                    Logger(#file).info("Settings closed")
-                                    dismiss()
-                                }
+                                CloseButton()
                             }
                         }
                 }

--- a/Bestuff/Sources/Stuff/Views/PlanTabView.swift
+++ b/Bestuff/Sources/Stuff/Views/PlanTabView.swift
@@ -7,6 +7,7 @@
 
 import SwiftData
 import SwiftUI
+import SwiftUtilities
 
 struct PlanTabView: View {
     @Environment(\.modelContext) private var modelContext
@@ -42,6 +43,9 @@ struct PlanTabView: View {
             }
             .navigationTitle(Text("Plan"))
             .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    CloseButton()
+                }
                 ToolbarItem(placement: .confirmationAction) {
                     if isProcessing {
                         ProgressView()

--- a/Bestuff/Sources/Stuff/Views/PredictStuffFormView.swift
+++ b/Bestuff/Sources/Stuff/Views/PredictStuffFormView.swift
@@ -7,6 +7,7 @@
 
 import SwiftData
 import SwiftUI
+import SwiftUtilities
 
 struct PredictStuffFormView: View {
     @Environment(\.dismiss)
@@ -45,10 +46,7 @@ struct PredictStuffFormView: View {
             .navigationTitle(Text("Predict Stuff"))
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel", systemImage: "xmark") {
-                        Logger(#file).info("PredictStuffFormView cancelled")
-                        dismiss()
-                    }
+                    CloseButton()
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     if isProcessing {

--- a/Bestuff/Sources/Stuff/Views/RecapTabView.swift
+++ b/Bestuff/Sources/Stuff/Views/RecapTabView.swift
@@ -1,5 +1,6 @@
 import SwiftData
 import SwiftUI
+import SwiftUtilities
 
 enum RecapPeriod: String, CaseIterable, Identifiable {
     case monthly
@@ -42,6 +43,11 @@ struct RecapTabView: View {
                 }
             }
             .navigationTitle(Text("Recap"))
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    CloseButton()
+                }
+            }
         } content: {
             if let date = selection {
                 RecapView(

--- a/Bestuff/Sources/Stuff/Views/StuffFormView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffFormView.swift
@@ -7,6 +7,7 @@
 
 import SwiftData
 import SwiftUI
+import SwiftUtilities
 
 struct StuffFormView: View {
     var stuff: Stuff?
@@ -51,9 +52,7 @@ struct StuffFormView: View {
             .navigationTitle(Text(stuff == nil ? "Add Stuff" : "Edit Stuff"))
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel", systemImage: "xmark") {
-                        dismiss()
-                    }
+                    CloseButton()
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save", systemImage: "tray.and.arrow.down", action: save)


### PR DESCRIPTION
## Summary
- replace custom close buttons with `CloseButton`
- show close button for settings tabs
- add missing close buttons on recap and plan views
- add `SwiftUtilities` imports

## Testing
- `pre-commit run --files Bestuff/Sources/Stuff/Views/PredictStuffFormView.swift Bestuff/Sources/Stuff/Views/StuffFormView.swift Bestuff/Sources/Stuff/Views/RecapTabView.swift Bestuff/Sources/Stuff/Views/PlanTabView.swift Bestuff/Sources/Settings/Views/SettingsView.swift`
- `swift test --parallel` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686f682637b483209dab7a268ba6a3ad