### PR TITLE
Add short term sections to plan tab

### DIFF
--- a/Bestuff/Sources/Stuff/Models/PlanPeriod.swift
+++ b/Bestuff/Sources/Stuff/Models/PlanPeriod.swift
@@ -8,6 +8,9 @@
 import AppIntents
 
 enum PlanPeriod: String, CaseIterable, Identifiable, AppEnum {
+    case today
+    case thisWeek
+    case nextTrip
     case nextMonth
     case nextYear
 
@@ -19,6 +22,9 @@ enum PlanPeriod: String, CaseIterable, Identifiable, AppEnum {
 
     nonisolated static var caseDisplayRepresentations: [Self: DisplayRepresentation] {
         [
+            .today: .init(stringLiteral: "Today"),
+            .thisWeek: .init(stringLiteral: "This Week"),
+            .nextTrip: .init(stringLiteral: "Next Trip"),
             .nextMonth: .init(stringLiteral: "Next Month"),
             .nextYear: .init(stringLiteral: "Next Year")
         ]
@@ -26,6 +32,12 @@ enum PlanPeriod: String, CaseIterable, Identifiable, AppEnum {
 
     var title: String {
         switch self {
+        case .today:
+            "Today"
+        case .thisWeek:
+            "This Week"
+        case .nextTrip:
+            "Next Trip"
         case .nextMonth:
             "Next Month"
         case .nextYear:
@@ -35,6 +47,12 @@ enum PlanPeriod: String, CaseIterable, Identifiable, AppEnum {
 
     var promptDescription: String {
         switch self {
+        case .today:
+            "today"
+        case .thisWeek:
+            "this week"
+        case .nextTrip:
+            "the next trip"
         case .nextMonth:
             "next month"
         case .nextYear:


### PR DESCRIPTION
## Summary
- support `today`, `thisWeek`, and `nextTrip` plan periods
- show plan suggestions in sectioned list instead of segmented picker

## Testing
- `swiftlint --fix --format --strict Bestuff/Sources/Stuff/Models/PlanPeriod.swift Bestuff/Sources/Stuff/Views/PlanTabView.swift` *(fails: Loading libsourcekitdInProc.so failed)*

------
https://chatgpt.com/codex/tasks/task_e_686fa07d1e108320b40a34d162e86c0d