### PR TITLE
Add sorting to stuff list

### DIFF
--- a/Bestuff/Sources/Stuff/Models/StuffSort.swift
+++ b/Bestuff/Sources/Stuff/Models/StuffSort.swift
@@ -11,9 +11,9 @@ enum StuffSort: String, CaseIterable, Identifiable {
     var title: String {
         switch self {
         case .occurredDateDescending:
-            "Date \u2193"
+            "Date \u{2193}"
         case .occurredDateAscending:
-            "Date \u2191"
+            "Date \u{2191}"
         case .titleAscending:
             "Title A-Z"
         case .titleDescending:

--- a/Bestuff/Sources/Stuff/Models/StuffSort.swift
+++ b/Bestuff/Sources/Stuff/Models/StuffSort.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+enum StuffSort: String, CaseIterable, Identifiable {
+    case occurredDateDescending
+    case occurredDateAscending
+    case titleAscending
+    case titleDescending
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .occurredDateDescending:
+            "Date \u2193"
+        case .occurredDateAscending:
+            "Date \u2191"
+        case .titleAscending:
+            "Title A-Z"
+        case .titleDescending:
+            "Title Z-A"
+        }
+    }
+
+    func areInIncreasingOrder(_ lhs: Stuff, _ rhs: Stuff) -> Bool {
+        switch self {
+        case .occurredDateDescending:
+            lhs.occurredAt > rhs.occurredAt
+        case .occurredDateAscending:
+            lhs.occurredAt < rhs.occurredAt
+        case .titleAscending:
+            lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+        case .titleDescending:
+            lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedDescending
+        }
+    }
+}

--- a/Bestuff/Sources/Stuff/Views/StuffListView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffListView.swift
@@ -7,6 +7,7 @@
 
 import SwiftData
 import SwiftUI
+import Foundation
 
 struct StuffListView: View {
     @Binding var selection: Stuff?
@@ -15,6 +16,7 @@ struct StuffListView: View {
     @Query(sort: \Stuff.occurredAt, order: .reverse)
     private var stuffs: [Stuff]
     @State private var searchText = ""
+    @State private var sort: StuffSort = .occurredDateDescending
     @State private var isRecapPresented = false
     @State private var isPlanPresented = false
     @State private var isSettingsPresented = false
@@ -38,6 +40,15 @@ struct StuffListView: View {
                 AddStuffButton()
             }
             ToolbarItemGroup(placement: .secondaryAction) {
+                Menu {
+                    Picker("Sort", selection: $sort) {
+                        ForEach(StuffSort.allCases) { option in
+                            Text(option.title).tag(option)
+                        }
+                    }
+                } label: {
+                    Label("Sort", systemImage: "arrow.up.arrow.down")
+                }
                 Button("Recap", systemImage: "calendar") {
                     Logger(#file).info("Recap button tapped")
                     isRecapPresented = true
@@ -66,13 +77,17 @@ struct StuffListView: View {
     }
 
     private var filteredStuffs: [Stuff] {
+        var result: [Stuff]
         if searchText.isEmpty {
-            stuffs
+            result = stuffs
         } else {
-            stuffs.filter { stuff in
-                stuff.title.localizedCaseInsensitiveContains(searchText) ||
-                    stuff.category.localizedCaseInsensitiveContains(searchText)
+            result = stuffs.filter { model in
+                model.title.localizedCaseInsensitiveContains(searchText) ||
+                    model.category.localizedCaseInsensitiveContains(searchText)
             }
+        }
+        return result.sorted { first, second in
+            sort.areInIncreasingOrder(first, second)
         }
     }
 


### PR DESCRIPTION
## Summary
- enable sorting options for stuffs
- sort items in list view

## Testing
- `swiftlint` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686fa129988883209e6910072f7a86d6