### PR TITLE
Fix StuffView layout

### DIFF
--- a/Bestuff/Sources/Stuff/Views/StuffView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffView.swift
@@ -15,8 +15,6 @@ struct StuffView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
-                Text(stuff.title)
-                    .font(.largeTitle.bold())
                 Text(stuff.category)
                     .font(.title3)
                     .foregroundStyle(.secondary)
@@ -36,7 +34,7 @@ struct StuffView: View {
             .padding()
             .background(.thinMaterial)
             .clipShape(
-                Capsule(style: .continuous)
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
             )
             .glassEffect()
             .padding()


### PR DESCRIPTION
## Summary
- avoid showing the title twice
- use `RoundedRectangle` for a softer shape

## Testing
- `swiftlint --fix --format --strict` *(fails: command not found)*
- `swift test` *(fails: no Package.swift found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc56315908320a0f721a3cab7d3b7