### PR TITLE
Refactor settings and debug navigation

### DIFF
--- a/Bestuff/Sources/Settings/Views/SettingsView.swift
+++ b/Bestuff/Sources/Settings/Views/SettingsView.swift
@@ -8,53 +8,33 @@
 import SwiftUI
 import SwiftUtilities
 
-enum SettingsTab: Hashable {
-    case general
-    case debug
-}
-
 struct SettingsView: View {
     @AppStorage("isDarkMode") private var isDarkMode = false
-    @State private var selection: SettingsTab = .general
 
     var body: some View {
-        TabView(selection: $selection.animation()) {
-            Tab("General", systemImage: "gear", value: SettingsTab.general) {
-                NavigationStack {
-                    List {
-                        Section("General") {
-                            Label("Version 1.0.0", systemImage: "number")
-                            Toggle("Dark Mode", isOn: $isDarkMode)
-                        }
-                        Section("Support") {
-                            Link(
-                                destination: URL(string: "mailto:support@example.com")!
-                            ) {
-                                Label("Contact Support", systemImage: "envelope")
-                            }
-                            Link(
-                                destination: URL(string: "https://example.com")!
-                            ) {
-                                Label("Visit Website", systemImage: "safari")
-                            }
-                        }
+        NavigationStack {
+            List {
+                Section("General") {
+                    Label("Version 1.0.0", systemImage: "number")
+                    Toggle("Dark Mode", isOn: $isDarkMode)
+                }
+                Section("Support") {
+                    Link(
+                        destination: URL(string: "mailto:support@example.com")!
+                    ) {
+                        Label("Contact Support", systemImage: "envelope")
                     }
-                    .navigationTitle(Text("Settings"))
-                    .toolbar {
-                        ToolbarItem(placement: .cancellationAction) {
-                            CloseButton()
-                        }
+                    Link(
+                        destination: URL(string: "https://example.com")!
+                    ) {
+                        Label("Visit Website", systemImage: "safari")
                     }
                 }
             }
-            Tab("Debug", systemImage: "ladybug", value: SettingsTab.debug) {
-                NavigationStack {
-                    DebugView()
-                        .toolbar {
-                            ToolbarItem(placement: .cancellationAction) {
-                                CloseButton()
-                            }
-                        }
+            .navigationTitle(Text("Settings"))
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    CloseButton()
                 }
             }
         }

--- a/Bestuff/Sources/Stuff/Views/StuffListView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffListView.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftData
 import SwiftUI
+import SwiftUtilities
 
 struct StuffListView: View {
     @Environment(\.modelContext)
@@ -88,12 +89,12 @@ struct StuffListView: View {
                         Logger(#file).info("Settings button tapped")
                         isSettingsPresented = true
                     }
-#if DEBUG
+                    #if DEBUG
                     Button("Debug", systemImage: "ladybug") {
                         Logger(#file).info("Debug button tapped")
                         isDebugPresented = true
                     }
-#endif
+                    #endif
                 } label: {
                     Label("Settings", systemImage: "gearshape")
                 }

--- a/Bestuff/Sources/Stuff/Views/StuffListView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffListView.swift
@@ -23,6 +23,7 @@ struct StuffListView: View {
     @State private var isRecapPresented = false
     @State private var isPlanPresented = false
     @State private var isSettingsPresented = false
+    @State private var isDebugPresented = false
     @State private var editingStuff: Stuff?
 
     init(selection: Binding<Stuff?>, searchText: Binding<String>) {
@@ -82,9 +83,19 @@ struct StuffListView: View {
                     isPlanPresented = true
                 }
                 .buttonStyle(.bordered)
-                Button("Settings", systemImage: "gearshape") {
-                    Logger(#file).info("Settings button tapped")
-                    isSettingsPresented = true
+                Menu {
+                    Button("Settings", systemImage: "gearshape") {
+                        Logger(#file).info("Settings button tapped")
+                        isSettingsPresented = true
+                    }
+#if DEBUG
+                    Button("Debug", systemImage: "ladybug") {
+                        Logger(#file).info("Debug button tapped")
+                        isDebugPresented = true
+                    }
+#endif
+                } label: {
+                    Label("Settings", systemImage: "gearshape")
                 }
             }
         }
@@ -96,6 +107,16 @@ struct StuffListView: View {
         }
         .sheet(isPresented: $isSettingsPresented) {
             SettingsView()
+        }
+        .sheet(isPresented: $isDebugPresented) {
+            NavigationStack {
+                DebugView()
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            CloseButton()
+                        }
+                    }
+            }
         }
         .sheet(item: $editingStuff) { stuff in
             StuffFormView(stuff: stuff)


### PR DESCRIPTION
## Summary
- decouple SettingsView from DebugView
- add Debug menu item in StuffListView during debug builds
- support closing DebugView presented from toolbar

## Testing
- `swiftlint --fix --format --strict` *(fails: Loading libsourcekitdInProc.so failed)*

------
https://chatgpt.com/codex/tasks/task_e_68708d42c0f48320a52abca4e7e1a078