### PR TITLE
Rename old tab views

### DIFF
--- a/Bestuff/Sources/Plan/Views/PlanSuggestionsView.swift
+++ b/Bestuff/Sources/Plan/Views/PlanSuggestionsView.swift
@@ -1,5 +1,5 @@
 //
-//  PlanTabView.swift
+//  PlanSuggestionsView.swift
 //  Bestuff
 //
 //  Created by Codex on 2025/07/12.
@@ -9,7 +9,7 @@ import SwiftData
 import SwiftUI
 import SwiftUtilities
 
-struct PlanTabView: View {
+struct PlanSuggestionsView: View {
     @Environment(\.modelContext) private var modelContext
     @State private var suggestions: [PlanPeriod: [String]] = [:]
     private let periods: [PlanPeriod] = [.today, .thisWeek, .nextTrip]
@@ -84,5 +84,5 @@ struct PlanTabView: View {
 }
 
 #Preview(traits: .sampleData) {
-    PlanTabView()
+    PlanSuggestionsView()
 }

--- a/Bestuff/Sources/Recap/Views/RecapOverviewView.swift
+++ b/Bestuff/Sources/Recap/Views/RecapOverviewView.swift
@@ -18,7 +18,7 @@ enum RecapPeriod: String, CaseIterable, Identifiable {
     }
 }
 
-struct RecapTabView: View {
+struct RecapOverviewView: View {
     @Query(sort: \Stuff.occurredAt, order: .reverse)
     private var stuffs: [Stuff]
     @State private var period: RecapPeriod = .monthly
@@ -123,5 +123,5 @@ struct RecapTabView: View {
 }
 
 #Preview(traits: .sampleData) {
-    RecapTabView()
+    RecapOverviewView()
 }

--- a/Bestuff/Sources/Stuff/Views/StuffListView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffListView.swift
@@ -89,10 +89,10 @@ struct StuffListView: View {
             }
         }
         .sheet(isPresented: $isRecapPresented) {
-            RecapTabView()
+            RecapOverviewView()
         }
         .sheet(isPresented: $isPlanPresented) {
-            PlanTabView()
+            PlanSuggestionsView()
         }
         .sheet(isPresented: $isSettingsPresented) {
             SettingsView()


### PR DESCRIPTION
## Summary
- rename `RecapTabView` to `RecapOverviewView`
- rename `PlanTabView` to `PlanSuggestionsView`
- update references in `StuffListView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68708d8051188320b9c56aa3b3f00eba