### PR TITLE
Rename StuffRowView to StuffRow

### DIFF
--- a/Bestuff/Sources/Recap/Views/RecapView.swift
+++ b/Bestuff/Sources/Recap/Views/RecapView.swift
@@ -16,7 +16,7 @@ struct RecapView: View {
     var body: some View {
         List(stuffs, selection: $selection) { stuff in
             NavigationLink(value: stuff) {
-                StuffRowView()
+                StuffRow()
                     .environment(stuff)
             }
         }

--- a/Bestuff/Sources/Stuff/Views/StuffListView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffListView.swift
@@ -34,7 +34,7 @@ struct StuffListView: View {
         List(selection: $selection) {
             ForEach(filteredStuffs) { stuff in
                 NavigationLink(value: stuff) {
-                    StuffRowView()
+                    StuffRow()
                         .environment(stuff)
                 }
                 .contextMenu(

--- a/Bestuff/Sources/Stuff/Views/StuffRow.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffRow.swift
@@ -1,5 +1,5 @@
 //
-//  StuffRowView.swift
+//  StuffRow.swift
 //  Bestuff
 //
 //  Created by Hiromu Nakano on 2025/07/08.
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct StuffRowView: View {
+struct StuffRow: View {
     @Environment(Stuff.self)
     private var stuff
 
@@ -27,7 +27,7 @@ struct StuffRowView: View {
 }
 
 #Preview(traits: .sampleData) {
-    StuffRowView()
+    StuffRow()
         .environment(
             Stuff(
                 title: "Sample",


### PR DESCRIPTION
## Summary
- rename `StuffRowView` to `StuffRow`
- update references in list and recap views

## Testing
- `pre-commit run --files Bestuff/Sources/Stuff/Views/StuffRow.swift Bestuff/Sources/Stuff/Views/StuffListView.swift Bestuff/Sources/Recap/Views/RecapView.swift` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68708dc7f46c8320a4e73e4c046186d3