### PR TITLE
Implement guarded model updates

### DIFF
--- a/Bestuff/Sources/Shared/Components/ModelContainerPreviewModifier.swift
+++ b/Bestuff/Sources/Shared/Components/ModelContainerPreviewModifier.swift
@@ -15,7 +15,7 @@ struct ModelContainerPreviewModifier: PreviewModifier {
         let context: ModelContext = .init(container)
         for stuff in SampleData.stuffs {
             context.insert(
-                Stuff(
+                Stuff.create(
                     title: stuff.title,
                     category: stuff.category,
                     note: stuff.note,

--- a/Bestuff/Sources/Stuff/Components/StuffRow.swift
+++ b/Bestuff/Sources/Stuff/Components/StuffRow.swift
@@ -29,7 +29,7 @@ struct StuffRow: View {
 #Preview(traits: .sampleData) {
     StuffRow()
         .environment(
-            Stuff(
+            Stuff.create(
                 title: "Sample",
                 category: "General",
                 occurredAt: .now,

--- a/Bestuff/Sources/Stuff/Entities/Stuff.swift
+++ b/Bestuff/Sources/Stuff/Entities/Stuff.swift
@@ -10,14 +10,14 @@ import SwiftData
 
 @Model
 nonisolated final class Stuff {
-    var title: String
-    var category: String
-    var note: String?
-    var score: Int
-    var occurredAt: Date
-    var createdAt: Date
+    private(set) var title: String
+    private(set) var category: String
+    private(set) var note: String?
+    private(set) var score: Int
+    private(set) var occurredAt: Date
+    private(set) var createdAt: Date
 
-    init(
+    private init(
         title: String,
         category: String,
         note: String? = nil,
@@ -31,5 +31,37 @@ nonisolated final class Stuff {
         self.score = score
         self.occurredAt = occurredAt
         self.createdAt = createdAt
+    }
+
+    static func create(
+        title: String,
+        category: String,
+        note: String? = nil,
+        score: Int = 0,
+        occurredAt: Date = .now,
+        createdAt: Date = .now
+    ) -> Stuff {
+        .init(
+            title: title,
+            category: category,
+            note: note,
+            score: score,
+            occurredAt: occurredAt,
+            createdAt: createdAt
+        )
+    }
+
+    func update(
+        title: String? = nil,
+        category: String? = nil,
+        note: String? = nil,
+        score: Int? = nil,
+        occurredAt: Date? = nil
+    ) {
+        if let title { self.title = title }
+        if let category { self.category = category }
+        if let note { self.note = note }
+        if let score { self.score = score }
+        if let occurredAt { self.occurredAt = occurredAt }
     }
 }

--- a/Bestuff/Sources/Stuff/Entities/StuffEntity.swift
+++ b/Bestuff/Sources/Stuff/Entities/StuffEntity.swift
@@ -61,8 +61,7 @@ extension StuffEntity: ModelBridgeable {
               ).first else {
             throw StuffError.stuffNotFound
         }
-        let updatedModel = model
-        updatedModel.occurredAt = occurredDate
-        return updatedModel
+        model.update(occurredAt: occurredDate)
+        return model
     }
 }

--- a/Bestuff/Sources/Stuff/Intents/CreateStuffIntent.swift
+++ b/Bestuff/Sources/Stuff/Intents/CreateStuffIntent.swift
@@ -27,7 +27,12 @@ struct CreateStuffIntent: AppIntent, IntentPerformer {
     static func perform(_ input: Input) throws -> Output {
         let (context, title, category, note, occurredAt) = input
         Logger(#file).info("Creating stuff titled '\(title)' in category '\(category)'")
-        let model = Stuff(title: title, category: category, note: note, occurredAt: occurredAt)
+        let model = Stuff.create(
+            title: title,
+            category: category,
+            note: note,
+            occurredAt: occurredAt
+        )
         context.insert(model)
         Logger(#file).notice("Created stuff with id \(String(describing: model.id))")
         return model

--- a/Bestuff/Sources/Stuff/Intents/PredictStuffIntent.swift
+++ b/Bestuff/Sources/Stuff/Intents/PredictStuffIntent.swift
@@ -21,7 +21,7 @@ struct PredictStuffIntent: AppIntent, IntentPerformer {
         let (context, speech) = input
         Logger(#file).info("Predicting stuff from speech")
         let prediction = try await generatePrediction(from: speech)
-        let model = Stuff(
+        let model = Stuff.create(
             title: prediction.title,
             category: prediction.category,
             note: prediction.note,

--- a/Bestuff/Sources/Stuff/Intents/UpdateStuffIntent.swift
+++ b/Bestuff/Sources/Stuff/Intents/UpdateStuffIntent.swift
@@ -1,0 +1,60 @@
+import AppIntents
+import SwiftData
+import SwiftUtilities
+
+struct UpdateStuffIntent: AppIntent, IntentPerformer {
+    typealias Input = (model: Stuff, title: String, category: String, note: String?, occurredAt: Date)
+    typealias Output = Stuff
+
+    nonisolated static var title: LocalizedStringResource { "Update Stuff" }
+
+    @Parameter(title: "Stuff")
+    private var stuff: StuffEntity
+
+    @Parameter(title: "Title")
+    private var title: String
+
+    @Parameter(title: "Category")
+    private var category: String
+
+    @Parameter(title: "Note")
+    private var note: String?
+
+    @Parameter(title: "Date")
+    private var occurredAt: Date
+
+    @Dependency private var modelContainer: ModelContainer
+
+    static func perform(_ input: Input) throws -> Output {
+        let (model, title, category, note, occurredAt) = input
+        Logger(#file).info("Updating stuff with id \(String(describing: model.id))")
+        model.update(
+            title: title,
+            category: category,
+            note: note,
+            occurredAt: occurredAt
+        )
+        Logger(#file).notice("Updated stuff with id \(String(describing: model.id))")
+        return model
+    }
+
+    func perform() throws -> some ReturnsValue<StuffEntity> {
+        Logger(#file).info("Running UpdateStuffIntent")
+        let model = try stuff.model(in: modelContainer.mainContext)
+        let updatedModel = try Self.perform(
+            (
+                model: model,
+                title: title,
+                category: category,
+                note: note,
+                occurredAt: occurredAt
+            )
+        )
+        guard let entity = StuffEntity(updatedModel) else {
+            Logger(#file).error("Failed to convert Stuff to StuffEntity")
+            throw StuffError.stuffNotFound
+        }
+        Logger(#file).notice("UpdateStuffIntent finished successfully")
+        return .result(value: entity)
+    }
+}

--- a/Bestuff/Sources/Stuff/Views/StuffFormView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffFormView.swift
@@ -71,10 +71,15 @@ struct StuffFormView: View {
         withAnimation {
             if let stuff {
                 Logger(#file).info("Updating stuff \(String(describing: stuff.id))")
-                stuff.title = title
-                stuff.category = category
-                stuff.note = note.isEmpty ? nil : note
-                stuff.occurredAt = occurredAt
+                _ = try? UpdateStuffIntent.perform(
+                    (
+                        model: stuff,
+                        title: title,
+                        category: category,
+                        note: note.isEmpty ? nil : note,
+                        occurredAt: occurredAt
+                    )
+                )
                 Logger(#file).notice("Updated stuff \(String(describing: stuff.id))")
             } else {
                 Logger(#file).info("Creating new stuff")
@@ -96,7 +101,7 @@ struct StuffFormView: View {
 
 #Preview(traits: .sampleData) {
     StuffFormView(
-        stuff: Stuff(
+        stuff: Stuff.create(
             title: "Sample",
             category: "General",
             occurredAt: .now,

--- a/Bestuff/Sources/Stuff/Views/StuffView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffView.swift
@@ -68,7 +68,7 @@ struct StuffView: View {
     NavigationStack {
         StuffView()
             .environment(
-                Stuff(
+                Stuff.create(
                     title: "Sample",
                     category: "General",
                     note: "Notes",

--- a/BestuffTests/BestuffTests.swift
+++ b/BestuffTests/BestuffTests.swift
@@ -11,7 +11,7 @@ import Testing
 
 struct BestuffTests {
     @Test func stuffInitialization() throws {
-        let stuff = Stuff(title: "Sample", category: "General", note: "Note", occurredAt: .now)
+        let stuff = Stuff.create(title: "Sample", category: "General", note: "Note", occurredAt: .now)
         #expect(stuff.title == "Sample")
         #expect(stuff.category == "General")
         #expect(stuff.note == "Note")

--- a/BestuffTests/UpdateStuffIntentTests.swift
+++ b/BestuffTests/UpdateStuffIntentTests.swift
@@ -1,0 +1,36 @@
+@testable import Bestuff
+import Foundation
+import SwiftData
+import Testing
+
+@MainActor
+struct UpdateStuffIntentTests {
+    let context: ModelContext
+
+    init() {
+        context = testContext
+    }
+
+    @Test func perform() throws {
+        let model = try CreateStuffIntent.perform(
+            (
+                context: context,
+                title: "Title",
+                category: "General",
+                note: nil,
+                occurredAt: .now
+            )
+        )
+        _ = try UpdateStuffIntent.perform(
+            (
+                model: model,
+                title: "Updated",
+                category: "General",
+                note: "Note",
+                occurredAt: .now
+            )
+        )
+        #expect(model.title == "Updated")
+        #expect(model.note == "Note")
+    }
+}


### PR DESCRIPTION
## Summary
- restrict mutability of `Stuff` model with `private(set)` properties
- add factory and update methods to encapsulate modifications
- introduce `UpdateStuffIntent` for editing existing items
- route form edits through the new intent
- update previews and tests for new APIs

## Testing
- `swiftlint` *(fails: command not found)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687095ab74908320b70f3dd83159f60d