### PR TITLE
Align navigation with split view design

### DIFF
--- a/Bestuff/Sources/ContentView.swift
+++ b/Bestuff/Sources/ContentView.swift
@@ -28,10 +28,6 @@ struct ContentView: View {
             }
         }
         .searchable(text: $searchText)
-        .navigationDestination(for: Stuff.self) { stuff in
-            StuffView()
-                .environment(stuff)
-        }
     }
 }
 

--- a/Bestuff/Sources/Plan/Views/PlanSuggestionsView.swift
+++ b/Bestuff/Sources/Plan/Views/PlanSuggestionsView.swift
@@ -27,17 +27,9 @@ struct PlanSuggestionsView: View {
                         if let actions = suggestions[period] {
                             Section(period.title) {
                                 ForEach(actions, id: \.self) { suggestion in
-                                    NavigationLink(
-                                        tag: suggestion,
-                                        selection: $selection,
-                                        destination: {
-                                            PlanView(suggestion: suggestion)
-                                        },
-                                        label: {
-                                            Text(suggestion)
-                                                .lineLimit(1)
-                                        }
-                                    )
+                                    Text(suggestion)
+                                        .lineLimit(1)
+                                        .tag(suggestion)
                                 }
                             }
                         }

--- a/Bestuff/Sources/Plan/Views/PlanSuggestionsView.swift
+++ b/Bestuff/Sources/Plan/Views/PlanSuggestionsView.swift
@@ -27,7 +27,13 @@ struct PlanSuggestionsView: View {
                         if let actions = suggestions[period] {
                             Section(period.title) {
                                 ForEach(actions, id: \.self) { suggestion in
-                                    NavigationLink(value: suggestion) {
+                                    NavigationLink(
+                                        destination: {
+                                            PlanView(suggestion: suggestion)
+                                        },
+                                        tag: suggestion,
+                                        selection: $selection
+                                    ) {
                                         Text(suggestion)
                                             .lineLimit(1)
                                     }
@@ -59,9 +65,6 @@ struct PlanSuggestionsView: View {
                 Text("Select Suggestion")
                     .foregroundStyle(.secondary)
             }
-        }
-        .navigationDestination(for: String.self) { suggestion in
-            PlanView(suggestion: suggestion)
         }
     }
 

--- a/Bestuff/Sources/Plan/Views/PlanSuggestionsView.swift
+++ b/Bestuff/Sources/Plan/Views/PlanSuggestionsView.swift
@@ -28,15 +28,16 @@ struct PlanSuggestionsView: View {
                             Section(period.title) {
                                 ForEach(actions, id: \.self) { suggestion in
                                     NavigationLink(
+                                        tag: suggestion,
+                                        selection: $selection,
                                         destination: {
                                             PlanView(suggestion: suggestion)
                                         },
-                                        tag: suggestion,
-                                        selection: $selection
-                                    ) {
-                                        Text(suggestion)
-                                            .lineLimit(1)
-                                    }
+                                        label: {
+                                            Text(suggestion)
+                                                .lineLimit(1)
+                                        }
+                                    )
                                 }
                             }
                         }

--- a/Bestuff/Sources/Recap/Views/RecapOverviewView.swift
+++ b/Bestuff/Sources/Recap/Views/RecapOverviewView.swift
@@ -38,6 +38,8 @@ struct RecapOverviewView: View {
 
                 ForEach(sortedKeys, id: \.self) { date in
                     NavigationLink(
+                        tag: date,
+                        selection: $selection,
                         destination: {
                             RecapView(
                                 date: date,
@@ -46,11 +48,10 @@ struct RecapOverviewView: View {
                                 selection: $stuffSelection
                             )
                         },
-                        tag: date,
-                        selection: $selection
-                    ) {
-                        Text(title(for: date))
-                    }
+                        label: {
+                            Text(title(for: date))
+                        }
+                    )
                 }
             }
             .navigationTitle(Text("Recap"))

--- a/Bestuff/Sources/Recap/Views/RecapOverviewView.swift
+++ b/Bestuff/Sources/Recap/Views/RecapOverviewView.swift
@@ -37,21 +37,8 @@ struct RecapOverviewView: View {
                 .padding(.vertical)
 
                 ForEach(sortedKeys, id: \.self) { date in
-                    NavigationLink(
-                        tag: date,
-                        selection: $selection,
-                        destination: {
-                            RecapView(
-                                date: date,
-                                period: period,
-                                stuffs: groupedStuffs[date] ?? [],
-                                selection: $stuffSelection
-                            )
-                        },
-                        label: {
-                            Text(title(for: date))
-                        }
-                    )
+                    Text(title(for: date))
+                        .tag(date)
                 }
             }
             .navigationTitle(Text("Recap"))

--- a/Bestuff/Sources/Recap/Views/RecapOverviewView.swift
+++ b/Bestuff/Sources/Recap/Views/RecapOverviewView.swift
@@ -37,7 +37,18 @@ struct RecapOverviewView: View {
                 .padding(.vertical)
 
                 ForEach(sortedKeys, id: \.self) { date in
-                    NavigationLink(value: date) {
+                    NavigationLink(
+                        destination: {
+                            RecapView(
+                                date: date,
+                                period: period,
+                                stuffs: groupedStuffs[date] ?? [],
+                                selection: $stuffSelection
+                            )
+                        },
+                        tag: date,
+                        selection: $selection
+                    ) {
                         Text(title(for: date))
                     }
                 }
@@ -68,18 +79,6 @@ struct RecapOverviewView: View {
                 Text("Select Stuff")
                     .foregroundStyle(.secondary)
             }
-        }
-        .navigationDestination(for: Date.self) { date in
-            RecapView(
-                date: date,
-                period: period,
-                stuffs: groupedStuffs[date] ?? [],
-                selection: $stuffSelection
-            )
-        }
-        .navigationDestination(for: Stuff.self) { stuff in
-            StuffView()
-                .environment(stuff)
         }
         .onDisappear {
             selection = nil

--- a/Bestuff/Sources/Recap/Views/RecapView.swift
+++ b/Bestuff/Sources/Recap/Views/RecapView.swift
@@ -15,7 +15,14 @@ struct RecapView: View {
 
     var body: some View {
         List(stuffs, selection: $selection) { stuff in
-            NavigationLink(value: stuff) {
+            NavigationLink(
+                destination: {
+                    StuffView()
+                        .environment(stuff)
+                },
+                tag: stuff,
+                selection: $selection
+            ) {
                 StuffRow()
                     .environment(stuff)
             }

--- a/Bestuff/Sources/Recap/Views/RecapView.swift
+++ b/Bestuff/Sources/Recap/Views/RecapView.swift
@@ -15,18 +15,9 @@ struct RecapView: View {
 
     var body: some View {
         List(stuffs, selection: $selection) { stuff in
-            NavigationLink(
-                tag: stuff,
-                selection: $selection,
-                destination: {
-                    StuffView()
-                        .environment(stuff)
-                },
-                label: {
-                    StuffRow()
-                        .environment(stuff)
-                }
-            )
+            StuffRow()
+                .environment(stuff)
+                .tag(stuff)
         }
         .navigationTitle(Text(title(for: date)))
     }

--- a/Bestuff/Sources/Recap/Views/RecapView.swift
+++ b/Bestuff/Sources/Recap/Views/RecapView.swift
@@ -16,16 +16,17 @@ struct RecapView: View {
     var body: some View {
         List(stuffs, selection: $selection) { stuff in
             NavigationLink(
+                tag: stuff,
+                selection: $selection,
                 destination: {
                     StuffView()
                         .environment(stuff)
                 },
-                tag: stuff,
-                selection: $selection
-            ) {
-                StuffRow()
-                    .environment(stuff)
-            }
+                label: {
+                    StuffRow()
+                        .environment(stuff)
+                }
+            )
         }
         .navigationTitle(Text(title(for: date)))
     }

--- a/Bestuff/Sources/Settings/Views/SettingsView.swift
+++ b/Bestuff/Sources/Settings/Views/SettingsView.swift
@@ -10,13 +10,12 @@ import SwiftUtilities
 
 struct SettingsView: View {
     var body: some View {
-        NavigationStack {
-            List {
-                Section("General") {
-                    Label("Version 1.0.0", systemImage: "number")
-                }
-                Section("Support") {
-                    Link(
+        List {
+            Section("General") {
+                Label("Version 1.0.0", systemImage: "number")
+            }
+            Section("Support") {
+                Link(
                         destination: URL(string: "mailto:support@example.com")!
                     ) {
                         Label("Contact Support", systemImage: "envelope")
@@ -27,12 +26,11 @@ struct SettingsView: View {
                         Label("Visit Website", systemImage: "safari")
                     }
                 }
-            }
-            .navigationTitle(Text("Settings"))
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    CloseButton()
-                }
+        }
+        .navigationTitle(Text("Settings"))
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                CloseButton()
             }
         }
     }

--- a/Bestuff/Sources/Stuff/Views/PredictStuffFormView.swift
+++ b/Bestuff/Sources/Stuff/Views/PredictStuffFormView.swift
@@ -21,11 +21,10 @@ struct PredictStuffFormView: View {
     @State private var transcriber = SpeechTranscriptionManager()
 
     var body: some View {
-        NavigationStack {
-            Form {
-                Section("Speech") {
-                    TextEditor(text: $speech)
-                        .frame(minHeight: 120, alignment: .topLeading)
+        Form {
+            Section("Speech") {
+                TextEditor(text: $speech)
+                    .frame(minHeight: 120, alignment: .topLeading)
                     HStack {
                         Spacer()
                         Button {
@@ -42,34 +41,33 @@ struct PredictStuffFormView: View {
                         }
                     }
                 }
+        }
+        .navigationTitle(Text("Predict Stuff"))
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                CloseButton()
             }
-            .navigationTitle(Text("Predict Stuff"))
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    CloseButton()
-                }
-                ToolbarItem(placement: .confirmationAction) {
-                    if isProcessing {
-                        ProgressView()
-                    } else {
-                        Button("Predict", systemImage: "wand.and.stars") {
-                            Logger(#file).info("Predict button tapped")
-                            predict()
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .tint(.accentColor)
-                        .disabled(speech.isEmpty)
+            ToolbarItem(placement: .confirmationAction) {
+                if isProcessing {
+                    ProgressView()
+                } else {
+                    Button("Predict", systemImage: "wand.and.stars") {
+                        Logger(#file).info("Predict button tapped")
+                        predict()
                     }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.accentColor)
+                    .disabled(speech.isEmpty)
                 }
             }
-            .onChange(of: transcriber.transcript) { _, newValue in
-                Logger(#file).info("Transcription updated")
-                speech = newValue
-            }
-            .onChange(of: transcriber.transcriptionError?.localizedDescription) { _, newErrorMessage in
-                Logger(#file).error("Transcription error: \(String(describing: newErrorMessage))")
-                errorMessage = newErrorMessage
-            }
+        }
+        .onChange(of: transcriber.transcript) { _, newValue in
+            Logger(#file).info("Transcription updated")
+            speech = newValue
+        }
+        .onChange(of: transcriber.transcriptionError?.localizedDescription) { _, newErrorMessage in
+            Logger(#file).error("Transcription error: \(String(describing: newErrorMessage))")
+            errorMessage = newErrorMessage
         }
         .alert("Speech Recognition Error", isPresented: Binding(
             get: { errorMessage != nil },

--- a/Bestuff/Sources/Stuff/Views/StuffFormView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffFormView.swift
@@ -32,38 +32,40 @@ struct StuffFormView: View {
     }
 
     var body: some View {
-        NavigationStack {
-            Form {
-                Section("Information") {
-                    TextField("Title", text: $title)
-                    TextField("Category", text: $category)
-                    TextField("Note", text: $note)
-                    DatePicker("Date", selection: $occurredAt, displayedComponents: .date)
-                }
-                Section("Options") {
-                    Button {
-                        Logger(#file).info("Predict from speech tapped")
-                        isPredictPresented = true
-                    } label: {
-                        Label("Predict from Speech", systemImage: "wand.and.stars")
-                    }
+        Form {
+            Section("Information") {
+                TextField("Title", text: $title)
+                TextField("Category", text: $category)
+                TextField("Note", text: $note)
+                DatePicker(
+                    "Date",
+                    selection: $occurredAt,
+                    displayedComponents: .date
+                )
+            }
+            Section("Options") {
+                Button {
+                    Logger(#file).info("Predict from speech tapped")
+                    isPredictPresented = true
+                } label: {
+                    Label("Predict from Speech", systemImage: "wand.and.stars")
                 }
             }
-            .navigationTitle(Text(stuff == nil ? "Add Stuff" : "Edit Stuff"))
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    CloseButton()
-                }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Save", systemImage: "tray.and.arrow.down", action: save)
-                        .buttonStyle(.borderedProminent)
-                        .tint(.accentColor)
-                        .disabled(title.isEmpty)
-                }
+        }
+        .navigationTitle(Text(stuff == nil ? "Add Stuff" : "Edit Stuff"))
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                CloseButton()
             }
-            .sheet(isPresented: $isPredictPresented) {
-                PredictStuffFormView()
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Save", systemImage: "tray.and.arrow.down", action: save)
+                    .buttonStyle(.borderedProminent)
+                    .tint(.accentColor)
+                    .disabled(title.isEmpty)
             }
+        }
+        .sheet(isPresented: $isPredictPresented) {
+            PredictStuffFormView()
         }
     }
 

--- a/Bestuff/Sources/Stuff/Views/StuffListView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffListView.swift
@@ -35,35 +35,26 @@ struct StuffListView: View {
     var body: some View {
         List(selection: $selection) {
             ForEach(filteredStuffs) { stuff in
-                NavigationLink(
-                    tag: stuff,
-                    selection: $selection,
-                    destination: {
-                        StuffView()
-                            .environment(stuff)
-                    },
-                    label: {
-                        StuffRow()
-                            .environment(stuff)
-                    }
-                )
-                .contextMenu(
-                    menuItems: {
-                        Button("Edit", systemImage: "pencil") {
-                            editingStuff = stuff
+                StuffRow()
+                    .environment(stuff)
+                    .tag(stuff)
+                    .contextMenu(
+                        menuItems: {
+                            Button("Edit", systemImage: "pencil") {
+                                editingStuff = stuff
+                            }
+                            Button(
+                                role: .destructive,
+                                action: { delete(stuff) }
+                            ) {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        },
+                        preview: {
+                            StuffView()
+                                .environment(stuff)
                         }
-                        Button(
-                            role: .destructive,
-                            action: { delete(stuff) }
-                        ) {
-                            Label("Delete", systemImage: "trash")
-                        }
-                    },
-                    preview: {
-                        StuffView()
-                            .environment(stuff)
-                    }
-                )
+                    )
             }
             .onDelete(perform: delete)
         }

--- a/Bestuff/Sources/Stuff/Views/StuffListView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffListView.swift
@@ -36,16 +36,17 @@ struct StuffListView: View {
         List(selection: $selection) {
             ForEach(filteredStuffs) { stuff in
                 NavigationLink(
+                    tag: stuff,
+                    selection: $selection,
                     destination: {
                         StuffView()
                             .environment(stuff)
                     },
-                    tag: stuff,
-                    selection: $selection
-                ) {
-                    StuffRow()
-                        .environment(stuff)
-                }
+                    label: {
+                        StuffRow()
+                            .environment(stuff)
+                    }
+                )
                 .contextMenu(
                     menuItems: {
                         Button("Edit", systemImage: "pencil") {

--- a/Bestuff/Sources/Stuff/Views/StuffListView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffListView.swift
@@ -35,7 +35,14 @@ struct StuffListView: View {
     var body: some View {
         List(selection: $selection) {
             ForEach(filteredStuffs) { stuff in
-                NavigationLink(value: stuff) {
+                NavigationLink(
+                    destination: {
+                        StuffView()
+                            .environment(stuff)
+                    },
+                    tag: stuff,
+                    selection: $selection
+                ) {
                     StuffRow()
                         .environment(stuff)
                 }
@@ -115,14 +122,12 @@ struct StuffListView: View {
             SettingsView()
         }
         .sheet(isPresented: $isDebugPresented) {
-            NavigationStack {
-                DebugView()
-                    .toolbar {
-                        ToolbarItem(placement: .cancellationAction) {
-                            CloseButton()
-                        }
+            DebugView()
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        CloseButton()
                     }
-            }
+                }
         }
         .sheet(item: $editingStuff) { stuff in
             StuffFormView(stuff: stuff)


### PR DESCRIPTION
## Summary
- drop leftover `navigationDestination` usage
- present forms and lists without `NavigationStack`
- link directly to detail views with explicit destinations

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687094b28a008320b7199ebad6c49478