### PR TITLE
Update view names for new conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,15 @@ if isDebugMode { logger.debug("Entering debug state") }
 tasks.filter { $0.isCompleted }
 ```
 
+### View naming conventions
+
+Name view structs according to the primary full-screen container:
+
+- Use `FooNavigationView` when the root is a `NavigationStack` or `NavigationSplitView`.
+- Use `FooListView` when the entire screen is a `List` or a scrollable list equivalent.
+- Use `FooFormView` when a `Form` is the main content.
+- Use `FooTabBar` when the screen is organized with a tab bar.
+
 ## Markdown Guidelines
 
 ### Follow markdownlint rules for Markdown files

--- a/Bestuff/Sources/BestuffApp.swift
+++ b/Bestuff/Sources/BestuffApp.swift
@@ -25,7 +25,7 @@ struct BestuffApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentNavigationView()
         }
         .modelContainer(sharedModelContainer)
         .commands {

--- a/Bestuff/Sources/ContentNavigationView.swift
+++ b/Bestuff/Sources/ContentNavigationView.swift
@@ -1,5 +1,5 @@
 //
-//  ContentView.swift
+//  ContentNavigationView.swift
 //  Bestuff
 //
 //  Created by Hiromu Nakano on 2025/07/08.
@@ -8,7 +8,7 @@
 import SwiftData
 import SwiftUI
 
-struct ContentView: View {
+struct ContentNavigationView: View {
     @State private var selection: Stuff?
     @State private var searchText = ""
 
@@ -32,5 +32,5 @@ struct ContentView: View {
 }
 
 #Preview(traits: .sampleData) {
-    ContentView()
+    ContentNavigationView()
 }

--- a/Bestuff/Sources/Plan/Views/PlanSuggestionsNavigationView.swift
+++ b/Bestuff/Sources/Plan/Views/PlanSuggestionsNavigationView.swift
@@ -1,5 +1,5 @@
 //
-//  PlanSuggestionsView.swift
+//  PlanSuggestionsNavigationView.swift
 //  Bestuff
 //
 //  Created by Codex on 2025/07/12.
@@ -9,7 +9,7 @@ import SwiftData
 import SwiftUI
 import SwiftUtilities
 
-struct PlanSuggestionsView: View {
+struct PlanSuggestionsNavigationView: View {
     @Environment(\.modelContext) private var modelContext
     @State private var suggestions: [PlanPeriod: [String]] = [:]
     private let periods: [PlanPeriod] = [.today, .thisWeek, .nextTrip]
@@ -80,5 +80,5 @@ struct PlanSuggestionsView: View {
 }
 
 #Preview(traits: .sampleData) {
-    PlanSuggestionsView()
+    PlanSuggestionsNavigationView()
 }

--- a/Bestuff/Sources/Recap/Views/RecapListView.swift
+++ b/Bestuff/Sources/Recap/Views/RecapListView.swift
@@ -1,5 +1,5 @@
 //
-//  RecapView.swift
+//  RecapListView.swift
 //  Bestuff
 //
 //  Created by Codex on 2025/07/22.
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct RecapView: View {
+struct RecapListView: View {
     let date: Date
     let period: RecapPeriod
     let stuffs: [Stuff]
@@ -35,7 +35,7 @@ struct RecapView: View {
 }
 
 #Preview(traits: .sampleData) {
-    RecapView(
+    RecapListView(
         date: .now,
         period: .monthly,
         stuffs: [],

--- a/Bestuff/Sources/Recap/Views/RecapOverviewNavigationView.swift
+++ b/Bestuff/Sources/Recap/Views/RecapOverviewNavigationView.swift
@@ -18,7 +18,7 @@ enum RecapPeriod: String, CaseIterable, Identifiable {
     }
 }
 
-struct RecapOverviewView: View {
+struct RecapOverviewNavigationView: View {
     @Query(sort: \Stuff.occurredAt, order: .reverse)
     private var stuffs: [Stuff]
     @State private var period: RecapPeriod = .monthly
@@ -49,7 +49,7 @@ struct RecapOverviewView: View {
             }
         } content: {
             if let date = selection {
-                RecapView(
+                RecapListView(
                     date: date,
                     period: period,
                     stuffs: groupedStuffs[date] ?? [],
@@ -110,5 +110,5 @@ struct RecapOverviewView: View {
 }
 
 #Preview(traits: .sampleData) {
-    RecapOverviewView()
+    RecapOverviewNavigationView()
 }

--- a/Bestuff/Sources/Settings/Views/SettingsListView.swift
+++ b/Bestuff/Sources/Settings/Views/SettingsListView.swift
@@ -1,5 +1,5 @@
 //
-//  SettingsView.swift
+//  SettingsListView.swift
 //  Bestuff
 //
 //  Created by Codex on 2025/07/09.
@@ -8,7 +8,7 @@
 import SwiftUI
 import SwiftUtilities
 
-struct SettingsView: View {
+struct SettingsListView: View {
     var body: some View {
         List {
             Section("General") {
@@ -37,5 +37,5 @@ struct SettingsView: View {
 }
 
 #Preview(traits: .sampleData) {
-    SettingsView()
+    SettingsListView()
 }

--- a/Bestuff/Sources/Shared/Views/DebugListView.swift
+++ b/Bestuff/Sources/Shared/Views/DebugListView.swift
@@ -1,5 +1,5 @@
 //
-//  DebugView.swift
+//  DebugListView.swift
 //  Bestuff
 //
 //  Created by Codex on 2025/07/09.
@@ -8,7 +8,7 @@
 import SwiftData
 import SwiftUI
 
-struct DebugView: View {
+struct DebugListView: View {
     @Environment(\.modelContext) private var modelContext
     @State private var isCreateAlertPresented = false
     @State private var isClearAlertPresented = false
@@ -142,5 +142,5 @@ struct SampleData {
 }
 
 #Preview(traits: .sampleData) {
-    NavigationStack { DebugView() }
+    NavigationStack { DebugListView() }
 }

--- a/Bestuff/Sources/Stuff/Views/StuffListView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffListView.swift
@@ -105,16 +105,16 @@ struct StuffListView: View {
             #endif
         }
         .sheet(isPresented: $isRecapPresented) {
-            RecapOverviewView()
+            RecapOverviewNavigationView()
         }
         .sheet(isPresented: $isPlanPresented) {
-            PlanSuggestionsView()
+            PlanSuggestionsNavigationView()
         }
         .sheet(isPresented: $isSettingsPresented) {
-            SettingsView()
+            SettingsListView()
         }
         .sheet(isPresented: $isDebugPresented) {
-            DebugView()
+            DebugListView()
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
                         CloseButton()


### PR DESCRIPTION
## Summary
- rename ContentView to ContentNavigationView
- rename Recap, Settings, Debug, and Plan suggestions views
- update sheet call sites

## Testing
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870b04aa8bc8320a37cee1d3857e8d2