### PR TITLE
Move toolbars into navigation views

### DIFF
--- a/Bestuff/Sources/Plan/Views/PlanListView.swift
+++ b/Bestuff/Sources/Plan/Views/PlanListView.swift
@@ -5,23 +5,18 @@
 //  Created by Hiromu Nakano on 2025/07/11.
 //
 
-import SwiftData
 import SwiftUI
 import SwiftUtilities
 
 struct PlanListView: View {
-    @Environment(\.modelContext)
-    private var modelContext
-
     @Binding private var selection: String?
-
-    @State private var suggestions: [PlanPeriod: [String]] = [:]
-    @State private var isProcessing = false
+    let suggestions: [PlanPeriod: [String]]
 
     private let periods: [PlanPeriod] = [.today, .thisWeek, .nextTrip]
 
-    init(selection: Binding<String?>) {
+    init(selection: Binding<String?>, suggestions: [PlanPeriod: [String]]) {
         _selection = selection
+        self.suggestions = suggestions
     }
 
     var body: some View {
@@ -44,42 +39,14 @@ struct PlanListView: View {
             }
         }
         .navigationTitle(Text("Plan"))
-        .toolbar {
-            ToolbarItem(placement: .cancellationAction) {
-                CloseButton()
-            }
-            ToolbarItem(placement: .confirmationAction) {
-                if isProcessing {
-                    ProgressView()
-                } else {
-                    Button("Generate", systemImage: "sparkles", action: generate)
-                        .buttonStyle(.borderedProminent)
-                        .tint(.accentColor)
-                }
-            }
-        }
-    }
-
-    private func generate() {
-        Logger(#file).info("Generating plan suggestions")
-        isProcessing = true
-        Task {
-            var results: [PlanPeriod: [String]] = [:]
-            for period in periods {
-                let result = try? await PlanStuffIntent.perform(
-                    (context: modelContext, period: period)
-                )
-                results[period] = result?.actions ?? []
-            }
-            suggestions = results
-            isProcessing = false
-            Logger(#file).notice("Generated suggestions count \(suggestions.values.flatMap(\.self).count)")
-        }
     }
 }
 
 #Preview(traits: .sampleData) {
     NavigationStack {
-        PlanListView(selection: .constant(nil))
+        PlanListView(
+            selection: .constant(nil),
+            suggestions: [:]
+        )
     }
 }

--- a/Bestuff/Sources/Plan/Views/PlanNavigationView.swift
+++ b/Bestuff/Sources/Plan/Views/PlanNavigationView.swift
@@ -5,17 +5,22 @@
 //  Created by Hiromu Nakano on 2025/07/11.
 //
 
-import SwiftData
 import SwiftUI
 import SwiftUtilities
 
 struct PlanNavigationView: View {
+    @Environment(\.modelContext)
+    private var modelContext
     @State private var suggestions: [PlanPeriod: [String]] = [:]
     @State private var selection: String?
+    @State private var isProcessing = false
 
     var body: some View {
         NavigationSplitView {
-            PlanListView(selection: $selection)
+            PlanListView(
+                selection: $selection,
+                suggestions: suggestions
+            )
         } detail: {
             if let suggestion = selection {
                 PlanView(suggestion: suggestion)
@@ -23,6 +28,37 @@ struct PlanNavigationView: View {
                 Text("Select Suggestion")
                     .foregroundStyle(.secondary)
             }
+        }
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                CloseButton()
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                if isProcessing {
+                    ProgressView()
+                } else {
+                    Button("Generate", systemImage: "sparkles", action: generate)
+                        .buttonStyle(.borderedProminent)
+                        .tint(.accentColor)
+                }
+            }
+        }
+    }
+
+    private func generate() {
+        Logger(#file).info("Generating plan suggestions")
+        isProcessing = true
+        Task {
+            var results: [PlanPeriod: [String]] = [:]
+            for period in [PlanPeriod.today, .thisWeek, .nextTrip] {
+                let result = try? await PlanStuffIntent.perform(
+                    (context: modelContext, period: period)
+                )
+                results[period] = result?.actions ?? []
+            }
+            suggestions = results
+            isProcessing = false
+            Logger(#file).notice("Generated suggestions count \(suggestions.values.flatMap(\.self).count)")
         }
     }
 }

--- a/Bestuff/Sources/Recap/Views/RecapListView.swift
+++ b/Bestuff/Sources/Recap/Views/RecapListView.swift
@@ -37,11 +37,6 @@ struct RecapListView: View {
             }
         }
         .navigationTitle(Text("Recap"))
-        .toolbar {
-            ToolbarItem(placement: .cancellationAction) {
-                CloseButton()
-            }
-        }
     }
 
     private var groupedStuffs: [Date: [Stuff]] {

--- a/Bestuff/Sources/Recap/Views/RecapNavigationView.swift
+++ b/Bestuff/Sources/Recap/Views/RecapNavigationView.swift
@@ -29,7 +29,8 @@ struct RecapNavigationView: View {
                 StuffListView(
                     stuffs: groupedStuffs[date] ?? [],
                     selection: $stuffSelection,
-                    searchText: $searchText
+                    searchText: $searchText,
+                    sort: .constant(.occurredDateDescending)
                 )
                 .navigationTitle(Text(title(for: date)))
             } else {
@@ -52,6 +53,11 @@ struct RecapNavigationView: View {
         .onChange(of: selection) { _, newValue in
             if newValue == nil {
                 stuffSelection = nil
+            }
+        }
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                CloseButton()
             }
         }
     }

--- a/Bestuff/Sources/Stuff/Views/StuffListView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffListView.swift
@@ -22,17 +22,19 @@ struct StuffListView: View {
     @Binding private var selection: Stuff?
     @Binding private var searchText: String
 
-    @State private var sort: StuffSort = .occurredDateDescending
-    @State private var isRecapPresented = false
-    @State private var isPlanPresented = false
-    @State private var isSettingsPresented = false
-    @State private var isDebugPresented = false
+    @Binding private var sort: StuffSort
     @State private var editingStuff: Stuff?
 
-    init(stuffs: [Stuff]? = nil, selection: Binding<Stuff?>, searchText: Binding<String>) {
+    init(
+        stuffs: [Stuff]? = nil,
+        selection: Binding<Stuff?>,
+        searchText: Binding<String>,
+        sort: Binding<StuffSort>
+    ) {
         overrideStuffs = stuffs
         _selection = selection
         _searchText = searchText
+        _sort = sort
     }
 
     private var stuffs: [Stuff] {
@@ -66,68 +68,6 @@ struct StuffListView: View {
             .onDelete(perform: delete)
         }
         .navigationTitle(Text("Best Stuff"))
-        .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                AddStuffButton()
-            }
-            ToolbarItem(placement: .primaryAction) {
-                Menu {
-                    Picker("Sort", selection: $sort) {
-                        ForEach(StuffSort.allCases) { option in
-                            Text(option.title).tag(option)
-                        }
-                    }
-                } label: {
-                    Label("Sort", systemImage: "arrow.up.arrow.down")
-                }
-            }
-
-            ToolbarItem(placement: .secondaryAction) {
-                Button("Recap", systemImage: "calendar") {
-                    Logger(#file).info("Recap button tapped")
-                    isRecapPresented = true
-                }
-                .buttonStyle(.bordered)
-            }
-            ToolbarItem(placement: .secondaryAction) {
-                Button("Plan", systemImage: "lightbulb") {
-                    Logger(#file).info("Plan button tapped")
-                    isPlanPresented = true
-                }
-                .buttonStyle(.bordered)
-            }
-            ToolbarItem(placement: .secondaryAction) {
-                Button("Settings", systemImage: "gearshape") {
-                    Logger(#file).info("Settings button tapped")
-                    isSettingsPresented = true
-                }
-            }
-            #if DEBUG
-            ToolbarItem(placement: .secondaryAction) {
-                Button("Debug", systemImage: "ladybug") {
-                    Logger(#file).info("Debug button tapped")
-                    isDebugPresented = true
-                }
-            }
-            #endif
-        }
-        .sheet(isPresented: $isRecapPresented) {
-            RecapNavigationView()
-        }
-        .sheet(isPresented: $isPlanPresented) {
-            PlanNavigationView()
-        }
-        .sheet(isPresented: $isSettingsPresented) {
-            SettingsListView()
-        }
-        .sheet(isPresented: $isDebugPresented) {
-            DebugListView()
-                .toolbar {
-                    ToolbarItem(placement: .cancellationAction) {
-                        CloseButton()
-                    }
-                }
-        }
         .sheet(item: $editingStuff) { stuff in
             StuffFormView(stuff: stuff)
         }
@@ -169,7 +109,8 @@ struct StuffListView: View {
     NavigationStack {
         StuffListView(
             selection: .constant(nil),
-            searchText: .constant("")
+            searchText: .constant(""),
+            sort: .constant(.occurredDateDescending)
         )
     }
 }

--- a/Bestuff/Sources/Stuff/Views/StuffNavigationView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffNavigationView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import SwiftUtilities
 
 struct StuffNavigationView: View {
     @State private var selection: Stuff?

--- a/Bestuff/Sources/Stuff/Views/StuffNavigationView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffNavigationView.swift
@@ -10,12 +10,18 @@ import SwiftUI
 struct StuffNavigationView: View {
     @State private var selection: Stuff?
     @State private var searchText = ""
+    @State private var sort: StuffSort = .occurredDateDescending
+    @State private var isRecapPresented = false
+    @State private var isPlanPresented = false
+    @State private var isSettingsPresented = false
+    @State private var isDebugPresented = false
 
     var body: some View {
         NavigationSplitView {
             StuffListView(
                 selection: $selection,
-                searchText: $searchText
+                searchText: $searchText,
+                sort: $sort
             )
         } detail: {
             if let stuff = selection {
@@ -27,6 +33,67 @@ struct StuffNavigationView: View {
             }
         }
         .searchable(text: $searchText)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                AddStuffButton()
+            }
+            ToolbarItem(placement: .primaryAction) {
+                Menu {
+                    Picker("Sort", selection: $sort) {
+                        ForEach(StuffSort.allCases) { option in
+                            Text(option.title).tag(option)
+                        }
+                    }
+                } label: {
+                    Label("Sort", systemImage: "arrow.up.arrow.down")
+                }
+            }
+            ToolbarItem(placement: .secondaryAction) {
+                Button("Recap", systemImage: "calendar") {
+                    Logger(#file).info("Recap button tapped")
+                    isRecapPresented = true
+                }
+                .buttonStyle(.bordered)
+            }
+            ToolbarItem(placement: .secondaryAction) {
+                Button("Plan", systemImage: "lightbulb") {
+                    Logger(#file).info("Plan button tapped")
+                    isPlanPresented = true
+                }
+                .buttonStyle(.bordered)
+            }
+            ToolbarItem(placement: .secondaryAction) {
+                Button("Settings", systemImage: "gearshape") {
+                    Logger(#file).info("Settings button tapped")
+                    isSettingsPresented = true
+                }
+            }
+            #if DEBUG
+            ToolbarItem(placement: .secondaryAction) {
+                Button("Debug", systemImage: "ladybug") {
+                    Logger(#file).info("Debug button tapped")
+                    isDebugPresented = true
+                }
+            }
+            #endif
+        }
+        .sheet(isPresented: $isRecapPresented) {
+            RecapNavigationView()
+        }
+        .sheet(isPresented: $isPlanPresented) {
+            PlanNavigationView()
+        }
+        .sheet(isPresented: $isSettingsPresented) {
+            SettingsListView()
+        }
+        .sheet(isPresented: $isDebugPresented) {
+            DebugListView()
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        CloseButton()
+                    }
+                }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- shift toolbar actions from list screens to navigation containers
- handle plan suggestion generation at the navigation level
- simplify list view previews and parameters

## Testing
- `swiftc --version`
- `swift test` *(fails: Could not find Package.swift)*
- `swiftlint --fix --format --strict` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870c243422c8320b11c52d4d4e72582