### PR TITLE
Fix single-line control flow statements

### DIFF
--- a/Bestuff/Sources/Shared/Models/SpeechTranscriptionManager.swift
+++ b/Bestuff/Sources/Shared/Models/SpeechTranscriptionManager.swift
@@ -175,12 +175,16 @@ final class SpeechTranscriptionManager {
 
     private func supported(locale: Locale) async -> Bool {
         let supported = await SpeechTranscriber.supportedLocales
-        return supported.map { $0.identifier(.bcp47) }.contains(locale.identifier(.bcp47))
+        return supported.map {
+            $0.identifier(.bcp47)
+        }.contains(locale.identifier(.bcp47))
     }
 
     private func installed(locale: Locale) async -> Bool {
         let installed = await Set(SpeechTranscriber.installedLocales)
-        return installed.map { $0.identifier(.bcp47) }.contains(locale.identifier(.bcp47))
+        return installed.map {
+            $0.identifier(.bcp47)
+        }.contains(locale.identifier(.bcp47))
     }
 
     private func downloadIfNeeded(for module: SpeechTranscriber) async throws {

--- a/Bestuff/Sources/Stuff/Entities/Stuff.swift
+++ b/Bestuff/Sources/Stuff/Entities/Stuff.swift
@@ -58,10 +58,20 @@ nonisolated final class Stuff {
         score: Int? = nil,
         occurredAt: Date? = nil
     ) {
-        if let title { self.title = title }
-        if let category { self.category = category }
-        if let note { self.note = note }
-        if let score { self.score = score }
-        if let occurredAt { self.occurredAt = occurredAt }
+        if let title {
+            self.title = title
+        }
+        if let category {
+            self.category = category
+        }
+        if let note {
+            self.note = note
+        }
+        if let score {
+            self.score = score
+        }
+        if let occurredAt {
+            self.occurredAt = occurredAt
+        }
     }
 }

--- a/Bestuff/Sources/Stuff/Entities/StuffEntity.swift
+++ b/Bestuff/Sources/Stuff/Entities/StuffEntity.swift
@@ -56,7 +56,9 @@ extension StuffEntity: ModelBridgeable {
         guard let persistentID = try? PersistentIdentifier(base64Encoded: id),
               let occurredDate = Self.dateFormatter.date(from: occurredAt),
               let model = try context.fetch(
-                FetchDescriptor<Stuff>(predicate: #Predicate { $0.id == persistentID })
+                FetchDescriptor<Stuff>(predicate: #Predicate {
+                    $0.id == persistentID
+                })
               ).first else {
             throw StuffError.stuffNotFound
         }

--- a/Bestuff/Sources/Stuff/Models/StuffEntityQuery.swift
+++ b/Bestuff/Sources/Stuff/Models/StuffEntityQuery.swift
@@ -9,7 +9,9 @@ struct StuffEntityQuery: EntityStringQuery {
         return try identifiers.compactMap { encodedID in
             guard let persistentID = try? PersistentIdentifier(base64Encoded: encodedID),
                   let model = try modelContainer.mainContext.fetch(
-                    FetchDescriptor<Stuff>(predicate: #Predicate { $0.id == persistentID })
+                    FetchDescriptor<Stuff>(predicate: #Predicate {
+                        $0.id == persistentID
+                    })
                   ).first else {
                 Logger(#file).error("Failed to decode identifier \(encodedID)")
                 return nil

--- a/Bestuff/Sources/Stuff/Views/PredictStuffFormView.swift
+++ b/Bestuff/Sources/Stuff/Views/PredictStuffFormView.swift
@@ -70,7 +70,11 @@ struct PredictStuffFormView: View {
         }
         .alert("Speech Recognition Error", isPresented: Binding(
             get: { errorMessage != nil },
-            set: { if !$0 { errorMessage = nil } }
+            set: {
+                if !$0 {
+                    errorMessage = nil
+                }
+            }
         ), actions: {
             Button("OK", systemImage: "checkmark", role: .cancel) {
                 errorMessage = nil

--- a/Bestuff/Sources/Stuff/Views/StuffListView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffListView.swift
@@ -152,7 +152,11 @@ struct StuffListView: View {
     }
 
     private func delete(_ stuff: Stuff) {
-        guard let index = stuffs.firstIndex(where: { $0.id == stuff.id }) else { return }
+        guard let index = stuffs.firstIndex(where: {
+            $0.id == stuff.id
+        }) else {
+            return
+        }
         delete(at: IndexSet(integer: index))
     }
 }


### PR DESCRIPTION
## Summary
- fix guard style in `delete` function
- move alert state setter to multiline form
- expand `if let` setters
- use multiline `#Predicate` clauses
- break map closures onto multiple lines

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project Bestuff.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870e34c43448320b310e5518fe98114