### PR TITLE
Fix variable naming and apostrophe

### DIFF
--- a/Bestuff/Sources/Stuff/Entities/StuffEntity.swift
+++ b/Bestuff/Sources/Stuff/Entities/StuffEntity.swift
@@ -31,10 +31,10 @@ extension StuffEntity: AppEntity {
 
 extension StuffEntity: ModelBridgeable {
     private static let dateFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "yyyyMMdd"
-        f.locale = Locale(identifier: "en_US_POSIX")
-        return f
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter
     }()
 
     init?(_ model: Stuff) {

--- a/BestuffUITests/BestuffUITests.swift
+++ b/BestuffUITests/BestuffUITests.swift
@@ -14,7 +14,7 @@ final class BestuffUITests: XCTestCase {
         // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
 
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+        // In UI tests it's important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
     }
 
     override func tearDownWithError() throws {


### PR DESCRIPTION
## Summary
- rename abbreviated variable in `StuffEntity.swift`
- fix curly apostrophe in tests

## Testing
- `pre-commit run --files Bestuff/Sources/Stuff/Entities/StuffEntity.swift BestuffUITests/BestuffUITests.swift` *(fails: error fetching SwiftLint)*
- `swift build` *(fails: could not find `Package.swift`)*

------
https://chatgpt.com/codex/tasks/task_e_6870e7390edc8320a859a9780d63f722