### PR TITLE
Add StoreKit subscription support

### DIFF
--- a/Bestuff/Sources/BestuffApp.swift
+++ b/Bestuff/Sources/BestuffApp.swift
@@ -5,6 +5,7 @@
 //  Created by Hiromu Nakano on 2025/07/08.
 //
 
+import StoreKitWrapper
 import SwiftData
 import SwiftUI
 
@@ -23,9 +24,20 @@ struct BestuffApp: App {
         }
     }()
 
+    private var sharedStore: Store = .init()
+
+    init() {
+        sharedStore.open(
+            groupID: "group.com.example.bestuff",
+            productIDs: ["com.example.bestuff.subscription"],
+            purchasedSubscriptionsDidSet: nil
+        )
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environment(sharedStore)
         }
         .modelContainer(sharedModelContainer)
         .commands {

--- a/Bestuff/Sources/Package/StoreKit/StoreListView.swift
+++ b/Bestuff/Sources/Package/StoreKit/StoreListView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct StoreListView: View {
+    var body: some View {
+        List {
+            StoreSection()
+        }
+        .navigationTitle("Subscription")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        StoreListView()
+    }
+}

--- a/Bestuff/Sources/Package/StoreKit/StoreSection.swift
+++ b/Bestuff/Sources/Package/StoreKit/StoreSection.swift
@@ -1,0 +1,15 @@
+import StoreKitWrapper
+import SwiftUI
+
+struct StoreSection: View {
+    @Environment(Store.self)
+    private var store
+
+    var body: some View {
+        store.buildSubscriptionSection()
+    }
+}
+
+#Preview {
+    StoreSection()
+}

--- a/Bestuff/Sources/Settings/Views/SettingsListView.swift
+++ b/Bestuff/Sources/Settings/Views/SettingsListView.swift
@@ -8,8 +8,17 @@
 import SwiftUI
 
 struct SettingsListView: View {
+    @AppStorage(BoolAppStorageKey.isSubscribeOn)
+    private var isSubscribeOn
     var body: some View {
         List {
+            if !isSubscribeOn {
+                NavigationLink {
+                    StoreListView()
+                } label: {
+                    Text("Subscription")
+                }
+            }
             Section("General") {
                 Label("Version 1.0.0", systemImage: "number")
             }

--- a/Bestuff/Sources/Shared/Models/AppStorageKey.swift
+++ b/Bestuff/Sources/Shared/Models/AppStorageKey.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+enum BoolAppStorageKey: String {
+    case isSubscribeOn = "a018f613"
+}
+
+extension AppStorage where Value == Bool {
+    init(_ key: BoolAppStorageKey) {
+        self.init(wrappedValue: false, key.rawValue)
+    }
+}


### PR DESCRIPTION
## Summary
- integrate `StoreKitWrapper` with new `Store` environment
- expose `StoreListView` and `StoreSection` for subscription UI
- track subscription state via `BoolAppStorageKey.isSubscribeOn`
- show subscription link in settings when not subscribed

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68711caae6bc8320a9188a0870477de4