### PR TITLE
Add Japanese localizations

### DIFF
--- a/Bestuff/Resources/Localizable.xcstrings
+++ b/Bestuff/Resources/Localizable.xcstrings
@@ -1,211 +1,645 @@
 {
-  "sourceLanguage" : "en",
+  "sourceLanguage" : "en", 
   "strings" : {
     "%lld" : {
-
-    },
+      "shouldTranslate" : false
+    }, 
     "1.0.0" : {
-
-    },
+      "shouldTranslate" : false
+    }, 
     "Actions" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "アクション"
+          }
+        }
+      }
+    }, 
     "Add Stuff" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "アイテムを追加"
+          }
+        }
+      }
+    }, 
     "App Version" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "アプリのバージョン"
+          }
+        }
+      }
+    }, 
     "Best Stuff" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "ベストアイテム"
+          }
+        }
+      }
+    }, 
     "Calendar" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "カレンダー"
+          }
+        }
+      }
+    }, 
     "Cancel" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "translated", 
             "value" : "キャンセル"
           }
         }
       }
-    },
+    }, 
     "Category" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "カテゴリー"
+          }
+        }
+      }
+    }, 
     "Clear" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "削除"
+          }
+        }
+      }
+    }, 
     "Clear All Data" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "すべてのデータを削除"
+          }
+        }
+      }
+    }, 
     "Clear all data?" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "すべてのデータを削除しますか？"
+          }
+        }
+      }
+    }, 
     "Contact Support" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "サポートに問い合わせる"
+          }
+        }
+      }
+    }, 
     "Create" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "作成"
+          }
+        }
+      }
+    }, 
     "Create Sample Data" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "サンプルデータを作成"
+          }
+        }
+      }
+    }, 
     "Create sample data?" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "サンプルデータを作成しますか？"
+          }
+        }
+      }
+    }, 
     "Create Stuff" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "アイテムを作成"
+          }
+        }
+      }
+    }, 
     "Created %@" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "%@ に作成"
+          }
+        }
+      }
+    }, 
     "Date" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "日付"
+          }
+        }
+      }
+    }, 
     "Debug" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "デバッグ"
+          }
+        }
+      }
+    }, 
     "Delete" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "削除"
+          }
+        }
+      }
+    }, 
     "Delete Stuff" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "アイテムを削除"
+          }
+        }
+      }
+    }, 
     "Edit Stuff" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "アイテムを編集"
+          }
+        }
+      }
+    }, 
     "General" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "一般"
+          }
+        }
+      }
+    }, 
     "Generate" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "生成"
+          }
+        }
+      }
+    }, 
     "Information" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "情報"
+          }
+        }
+      }
+    }, 
     "Language" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "言語"
+          }
+        }
+      }
+    }, 
     "Next Month" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "翌月"
+          }
+        }
+      }
+    }, 
     "Next Trip" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "次の旅行"
+          }
+        }
+      }
+    }, 
     "Next Year" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "翌年"
+          }
+        }
+      }
+    }, 
     "No suggestions yet" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "まだ候補がありません"
+          }
+        }
+      }
+    }, 
     "Note" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "メモ"
+          }
+        }
+      }
+    }, 
     "Occurred %@" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "%@ に発生"
+          }
+        }
+      }
+    }, 
     "OK" : {
       "shouldTranslate" : false
-    },
+    }, 
     "Options" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "オプション"
+          }
+        }
+      }
+    }, 
     "OS Version" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "OSバージョン"
+          }
+        }
+      }
+    }, 
     "Period" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "期間"
+          }
+        }
+      }
+    }, 
     "Plan" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "計画"
+          }
+        }
+      }
+    }, 
     "Plan Period" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "計画期間"
+          }
+        }
+      }
+    }, 
     "Plan Stuff" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "アイテムを計画"
+          }
+        }
+      }
+    }, 
     "Predict" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "予測"
+          }
+        }
+      }
+    }, 
     "Predict Stuff" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "アイテムを予測"
+          }
+        }
+      }
+    }, 
     "Recap" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "振り返り"
+          }
+        }
+      }
+    }, 
     "Region" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "地域"
+          }
+        }
+      }
+    }, 
     "Save" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "保存"
+          }
+        }
+      }
+    }, 
     "Score: %lld" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "スコア: %lld"
+          }
+        }
+      }
+    }, 
     "Select Period" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "期間を選択"
+          }
+        }
+      }
+    }, 
     "Select Stuff" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "アイテムを選択"
+          }
+        }
+      }
+    }, 
     "Select Suggestion" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "候補を選択"
+          }
+        }
+      }
+    }, 
     "Settings" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "設定"
+          }
+        }
+      }
+    }, 
     "Sort" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "並べ替え"
+          }
+        }
+      }
+    }, 
     "Speech" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "音声"
+          }
+        }
+      }
+    }, 
     "Speech Recognition Error" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "音声認識エラー"
+          }
+        }
+      }
+    }, 
     "Stored Items" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "保存されたアイテム"
+          }
+        }
+      }
+    }, 
     "Stuff" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "アイテム"
+          }
+        }
+      }
+    }, 
     "Suggestion" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "候補"
+          }
+        }
+      }
+    }, 
     "Support" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "サポート"
+          }
+        }
+      }
+    }, 
     "This Week" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "今週"
+          }
+        }
+      }
+    }, 
     "This will add example stuff to the list." : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "これにより例のアイテムがリストに追加されます。"
+          }
+        }
+      }
+    }, 
     "This will permanently delete all stuff." : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "これによりすべてのアイテムが完全に削除されます。"
+          }
+        }
+      }
+    }, 
     "Time Zone" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "タイムゾーン"
+          }
+        }
+      }
+    }, 
     "Title" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "タイトル"
+          }
+        }
+      }
+    }, 
     "Today" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "今日"
+          }
+        }
+      }
+    }, 
     "Update Stuff" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "アイテムを更新"
+          }
+        }
+      }
+    }, 
     "Version 1.0.0" : {
-
-    },
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "バージョン 1.0.0"
+          }
+        }
+      }
+    }, 
     "Visit Website" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated", 
+            "value" : "ウェブサイトを表示"
+          }
+        }
+      }
     }
-  },
+  }, 
   "version" : "1.1"
 }


### PR DESCRIPTION
## Summary
- add Japanese translations for every key in `Localizable.xcstrings`
- mark numeric strings as not needing translation

## Testing
- `pre-commit run --files Bestuff/Resources/Localizable.xcstrings` *(fails: error 403 from github.com)*

------
https://chatgpt.com/codex/tasks/task_e_68711dfab74883209e33d03bbf499f81