### PR TITLE
Implement forced update feature

### DIFF
--- a/Bestuff/Sources/BestuffApp.swift
+++ b/Bestuff/Sources/BestuffApp.swift
@@ -25,6 +25,7 @@ struct BestuffApp: App {
     }()
 
     private var sharedStore: Store = .init()
+    private var sharedConfigurationService: ConfigurationService = .init()
 
     init() {
         sharedStore.open(
@@ -38,6 +39,7 @@ struct BestuffApp: App {
         WindowGroup {
             ContentView()
                 .environment(sharedStore)
+                .environment(sharedConfigurationService)
         }
         .modelContainer(sharedModelContainer)
         .commands {

--- a/Bestuff/Sources/Configuration/Models/Configuration.swift
+++ b/Bestuff/Sources/Configuration/Models/Configuration.swift
@@ -1,0 +1,12 @@
+//
+//  Configuration.swift
+//  Bestuff
+//
+//  Created by Codex on 2025/07/12.
+//
+
+import Foundation
+
+struct Configuration: Decodable {
+    let requiredVersion: String
+}

--- a/Bestuff/Sources/Configuration/Models/ConfigurationService.swift
+++ b/Bestuff/Sources/Configuration/Models/ConfigurationService.swift
@@ -1,0 +1,34 @@
+//
+//  ConfigurationService.swift
+//  Bestuff
+//
+//  Created by Codex on 2025/07/12.
+//
+
+import Foundation
+import Observation
+
+@Observable
+final class ConfigurationService {
+    private(set) var configuration: Configuration?
+
+    private let decoder = JSONDecoder()
+
+    func load() async throws {
+        let data = try await URLSession.shared.data(
+            from: .init(
+                string: "https://raw.githubusercontent.com/muhiro12/Bestuff/main/.config.json"
+            )!
+        ).0
+        configuration = try decoder.decode(Configuration.self, from: data)
+    }
+
+    func isUpdateRequired() -> Bool {
+        guard let current = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+              let required = configuration?.requiredVersion,
+              Bundle.main.bundleIdentifier?.contains("playgrounds") == false else {
+            return false
+        }
+        return current.compare(required, options: .numeric) == .orderedAscending
+    }
+}

--- a/Bestuff/Sources/ContentView.swift
+++ b/Bestuff/Sources/ContentView.swift
@@ -8,8 +8,38 @@
 import SwiftUI
 
 struct ContentView: View {
+    @Environment(ConfigurationService.self)
+    private var configurationService
+    @Environment(\.scenePhase)
+    private var scenePhase
+
+    @State private var isUpdateAlertPresented = false
     var body: some View {
         StuffNavigationView()
+            .alert(Text("Update Required"), isPresented: $isUpdateAlertPresented) {
+                Button {
+                    UIApplication.shared.open(
+                        .init(string: "https://apps.apple.com/jp/app/incomes/id1584472982")!
+                    )
+                } label: {
+                    Text("Open App Store")
+                }
+            } message: {
+                Text("Please update Bestuff to the latest version to continue using it.")
+            }
+            .task {
+                try? await configurationService.load()
+                isUpdateAlertPresented = configurationService.isUpdateRequired()
+            }
+            .onChange(of: scenePhase) {
+                guard scenePhase == .active else {
+                    return
+                }
+                Task {
+                    try? await configurationService.load()
+                    isUpdateAlertPresented = configurationService.isUpdateRequired()
+                }
+            }
     }
 }
 

--- a/BestuffTests/ConfigurationServiceTests.swift
+++ b/BestuffTests/ConfigurationServiceTests.swift
@@ -1,0 +1,10 @@
+@testable import Bestuff
+import Testing
+
+struct ConfigurationServiceTests {
+    @Test func updateCheck() async throws {
+        let service = ConfigurationService()
+        try? await service.load()
+        _ = service.isUpdateRequired()
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `Configuration` model and `ConfigurationService`
- inject `ConfigurationService` via `BestuffApp`
- show update alert in `ContentView` based on remote config
- add basic test for `ConfigurationService`

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6871abe0368083209c856b65d4ff37b1