### PR TITLE
Add tag browsing UI

### DIFF
--- a/Bestuff/Sources/ContentView.swift
+++ b/Bestuff/Sources/ContentView.swift
@@ -15,7 +15,7 @@ struct ContentView: View {
 
     @State private var isUpdateAlertPresented = false
     var body: some View {
-        StuffNavigationView()
+        HomeTabBar()
             .alert(Text("Update Required"), isPresented: $isUpdateAlertPresented) {
                 Button {
                     UIApplication.shared.open(

--- a/Bestuff/Sources/Home/Views/HomeTabBar.swift
+++ b/Bestuff/Sources/Home/Views/HomeTabBar.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct HomeTabBar: View {
+    var body: some View {
+        TabView {
+            StuffNavigationView()
+                .tabItem {
+                    Label("Stuff", systemImage: "list.bullet")
+                }
+            TagNavigationView()
+                .tabItem {
+                    Label("Tags", systemImage: "tag")
+                }
+        }
+    }
+}
+
+#Preview(traits: .sampleData) {
+    HomeTabBar()
+}

--- a/Bestuff/Sources/Tag/Components/AddTagButton.swift
+++ b/Bestuff/Sources/Tag/Components/AddTagButton.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct AddTagButton: View {
+    @State private var isPresented = false
+
+    var body: some View {
+        Button("Add Tag", systemImage: "plus") {
+            Logger(#file).info("TagFormButton tapped for new")
+            isPresented = true
+        }
+        .glassEffect()
+        .sheet(isPresented: $isPresented) {
+            NavigationStack {
+                TagFormView()
+            }
+        }
+    }
+}
+
+#Preview(traits: .sampleData) {
+    AddTagButton()
+}

--- a/Bestuff/Sources/Tag/Views/TagFormView.swift
+++ b/Bestuff/Sources/Tag/Views/TagFormView.swift
@@ -1,0 +1,54 @@
+import SwiftData
+import SwiftUI
+
+struct TagFormView: View {
+    @Environment(Tag.self)
+    private var tag: Tag?
+    @Environment(\.dismiss)
+    private var dismiss
+    @Environment(\.modelContext)
+    private var modelContext
+
+    @State private var name = ""
+
+    var body: some View {
+        Form {
+            TextField("Name", text: $name)
+        }
+        .navigationTitle(tag == nil ? "Add Tag" : "Edit Tag")
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                CloseButton()
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Save", systemImage: "tray.and.arrow.down", action: save)
+                    .buttonStyle(.borderedProminent)
+                    .tint(.accentColor)
+                    .disabled(name.isEmpty)
+            }
+        }
+        .task {
+            name = tag?.name ?? .empty
+        }
+    }
+
+    private func save() {
+        withAnimation {
+            if let tag {
+                Logger(#file).info("Updating tag \(String(describing: tag.id))")
+                tag.update(name: name)
+                Logger(#file).notice("Updated tag \(String(describing: tag.id))")
+            } else {
+                Logger(#file).info("Creating new tag")
+                modelContext.insert(Tag.create(name: name))
+                Logger(#file).notice("Created new tag")
+            }
+            dismiss()
+        }
+    }
+}
+
+#Preview(traits: .sampleData) {
+    TagFormView()
+        .modelContainer(for: Tag.self, inMemory: true)
+}

--- a/Bestuff/Sources/Tag/Views/TagListView.swift
+++ b/Bestuff/Sources/Tag/Views/TagListView.swift
@@ -9,23 +9,43 @@ struct TagListView: View {
     private var queriedTags: [Tag]
 
     @Binding private var selection: Tag?
+    @Binding private var searchText: String
 
-    init(selection: Binding<Tag?>) {
+    init(selection: Binding<Tag?>, searchText: Binding<String>) {
         _selection = selection
+        _searchText = searchText
     }
 
     var body: some View {
         List(selection: $selection) {
-            ForEach(queriedTags) { tag in
+            ForEach(filteredTags) { tag in
                 Text(tag.name).tag(tag)
             }
         }
         .navigationTitle("Tags")
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                AddTagButton()
+            }
+        }
+    }
+
+    private var filteredTags: [Tag] {
+        if searchText.isEmpty {
+            return queriedTags
+        } else {
+            return queriedTags.filter {
+                $0.name.localizedCaseInsensitiveContains(searchText)
+            }
+        }
     }
 }
 
 #Preview(traits: .sampleData) {
     NavigationStack {
-        TagListView(selection: .constant(nil))
+        TagListView(
+            selection: .constant(nil),
+            searchText: .constant("")
+        )
     }
 }

--- a/Bestuff/Sources/Tag/Views/TagNavigationView.swift
+++ b/Bestuff/Sources/Tag/Views/TagNavigationView.swift
@@ -2,10 +2,14 @@ import SwiftUI
 
 struct TagNavigationView: View {
     @State private var selection: Tag?
+    @State private var searchText = ""
 
     var body: some View {
         NavigationSplitView {
-            TagListView(selection: $selection)
+            TagListView(
+                selection: $selection,
+                searchText: $searchText
+            )
         } detail: {
             if let tag = selection {
                 StuffListView(
@@ -19,6 +23,7 @@ struct TagNavigationView: View {
                     .foregroundStyle(.secondary)
             }
         }
+        .searchable(text: $searchText)
     }
 }
 


### PR DESCRIPTION
## Summary
- create `HomeTabBar` with tabs for stuff and tags
- add ability to create tags via `TagFormView` and `AddTagButton`
- enhance `TagListView` with search and toolbar button
- show tags in a searchable navigation view
- embed the new tab bar in `ContentView`

## Testing
- `swiftlint --fix --format --strict` *(fails: Loading libsourcekitdInProc.so failed)*
- `pre-commit run --files Bestuff/Sources/ContentView.swift Bestuff/Sources/Tag/Views/TagListView.swift Bestuff/Sources/Tag/Views/TagNavigationView.swift Bestuff/Sources/Tag/Components/AddTagButton.swift Bestuff/Sources/Tag/Views/TagFormView.swift Bestuff/Sources/Home/Views/HomeTabBar.swift` *(fails: RPC failed; HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_6871d05f28c08320846e1b07f1aa8615