### PR TITLE
Implement tag selection and dedup

### DIFF
--- a/Bestuff/Sources/Tag/Intents/CreateTagIntent.swift
+++ b/Bestuff/Sources/Tag/Intents/CreateTagIntent.swift
@@ -1,0 +1,27 @@
+import AppIntents
+import SwiftData
+
+struct CreateTagIntent: AppIntent, IntentPerformer {
+    typealias Input = (context: ModelContext, name: String)
+    typealias Output = Tag
+
+    @Parameter(title: "Name")
+    private var name: String
+    @Dependency private var modelContainer: ModelContainer
+
+    nonisolated static var title: LocalizedStringResource {
+        "Create Tag"
+    }
+
+    static func perform(_ input: Input) throws -> Output {
+        Tag.findOrCreate(name: input.name, in: input.context)
+    }
+
+    func perform() throws -> some ReturnsValue<TagEntity> {
+        let tag = try Self.perform((context: modelContainer.mainContext, name: name))
+        guard let entity = TagEntity(tag) else {
+            throw TagError.tagNotFound
+        }
+        return .result(value: entity)
+    }
+}

--- a/Bestuff/Sources/Tag/Intents/UpdateTagIntent.swift
+++ b/Bestuff/Sources/Tag/Intents/UpdateTagIntent.swift
@@ -1,0 +1,33 @@
+import AppIntents
+import SwiftData
+
+struct UpdateTagIntent: AppIntent, IntentPerformer {
+    typealias Input = (model: Tag, name: String)
+    typealias Output = Tag
+
+    @Parameter(title: "Tag")
+    private var tag: TagEntity
+
+    @Parameter(title: "Name")
+    private var name: String
+    
+    @Dependency private var modelContainer: ModelContainer
+
+    nonisolated static var title: LocalizedStringResource {
+        "Update Tag"
+    }
+
+    static func perform(_ input: Input) throws -> Output {
+        input.model.update(name: input.name)
+        return input.model
+    }
+
+    func perform() throws -> some ReturnsValue<TagEntity> {
+        let model = try tag.model(in: modelContainer.mainContext)
+        let updated = try Self.perform((model: model, name: name))
+        guard let entity = TagEntity(updated) else {
+            throw TagError.tagNotFound
+        }
+        return .result(value: entity)
+    }
+}

--- a/Bestuff/Sources/Tag/Models/Tag.swift
+++ b/Bestuff/Sources/Tag/Models/Tag.swift
@@ -18,4 +18,21 @@ nonisolated final class Tag {
     func update(name: String) {
         self.name = name
     }
+
+    static func fetch(byName name: String, in context: ModelContext) throws -> Tag? {
+        try context.fetch(
+            FetchDescriptor<Tag>(
+                predicate: #Predicate { $0.name.lowercased() == name.lowercased() }
+            )
+        ).first
+    }
+
+    static func findOrCreate(name: String, in context: ModelContext) -> Tag {
+        if let existing = try? fetch(byName: name, in: context) {
+            return existing
+        }
+        let tag = create(name: name)
+        context.insert(tag)
+        return tag
+    }
 }

--- a/Bestuff/Sources/Tag/Views/TagFormView.swift
+++ b/Bestuff/Sources/Tag/Views/TagFormView.swift
@@ -36,11 +36,11 @@ struct TagFormView: View {
         withAnimation {
             if let tag {
                 Logger(#file).info("Updating tag \(String(describing: tag.id))")
-                tag.update(name: name)
+                _ = try? UpdateTagIntent.perform((model: tag, name: name))
                 Logger(#file).notice("Updated tag \(String(describing: tag.id))")
             } else {
                 Logger(#file).info("Creating new tag")
-                modelContext.insert(Tag.create(name: name))
+                _ = try? CreateTagIntent.perform((context: modelContext, name: name))
                 Logger(#file).notice("Created new tag")
             }
             dismiss()

--- a/Bestuff/Sources/Tag/Views/TagPickerListView.swift
+++ b/Bestuff/Sources/Tag/Views/TagPickerListView.swift
@@ -1,0 +1,47 @@
+import SwiftData
+import SwiftUI
+
+struct TagPickerListView: View {
+    @Environment(\.dismiss)
+    private var dismiss
+    @Environment(\.modelContext)
+    private var modelContext
+    @State private var tags: [Tag] = []
+
+    @Binding private var selection: Set<Tag>
+
+    init(selection: Binding<Set<Tag>>) {
+        _selection = selection
+    }
+
+    var body: some View {
+        List(tags, selection: $selection) { tag in
+            Text(tag.name)
+                .tag(tag)
+        }
+        .environment(\.editMode, .constant(.active))
+        .navigationTitle("Tags")
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                CloseButton()
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Done", action: { dismiss() })
+                    .buttonStyle(.borderedProminent)
+                    .tint(.accentColor)
+            }
+        }
+        .task {
+            if let entities = try? GetAllTagsIntent.perform(modelContext) {
+                tags = entities.compactMap { try? $0.model(in: modelContext) }
+            }
+        }
+    }
+}
+
+#Preview(traits: .sampleData) {
+    NavigationStack {
+        TagPickerListView(selection: .constant([]))
+    }
+    .modelContainer(for: Tag.self, inMemory: true)
+}

--- a/BestuffTests/CreateStuffIntentTests.swift
+++ b/BestuffTests/CreateStuffIntentTests.swift
@@ -11,7 +11,7 @@ struct CreateStuffIntentTests {
     }
 
     @Test func perform() throws {
-        _ = try CreateStuffIntent.perform(
+        let model = try CreateStuffIntent.perform(
             (
                 context: context,
                 title: "Title",
@@ -20,8 +20,10 @@ struct CreateStuffIntentTests {
                 occurredAt: .now
             )
         )
+        let tag = try CreateTagIntent.perform((context: context, name: "Tag"))
+        model.update(tags: [tag])
         let stuffs = try context.fetch(FetchDescriptor<Stuff>())
         #expect(stuffs.count == 1)
-        #expect(stuffs.first?.title == "Title")
+        #expect(stuffs.first?.tags?.count == 1)
     }
 }

--- a/BestuffTests/TagTests.swift
+++ b/BestuffTests/TagTests.swift
@@ -10,10 +10,17 @@ struct TagTests {
     }
 
     @Test func createAndFetch() throws {
-        let tag = Tag.create(name: "Sample")
-        context.insert(tag)
+        _ = try CreateTagIntent.perform((context: context, name: "Sample"))
         let fetched = try context.fetch(FetchDescriptor<Bestuff.Tag>())
         #expect(fetched.count == 1)
         #expect(fetched.first?.name == "Sample")
+    }
+
+    @Test func avoidDuplicates() throws {
+        let first = try CreateTagIntent.perform((context: context, name: "Dup"))
+        let second = try CreateTagIntent.perform((context: context, name: "Dup"))
+        let fetched = try context.fetch(FetchDescriptor<Bestuff.Tag>())
+        #expect(fetched.count == 1)
+        #expect(first.id == second.id)
     }
 }

--- a/BestuffTests/UpdateStuffIntentTests.swift
+++ b/BestuffTests/UpdateStuffIntentTests.swift
@@ -29,7 +29,10 @@ struct UpdateStuffIntentTests {
                 occurredAt: .now
             )
         )
+        let tag = try CreateTagIntent.perform((context: context, name: "Tag"))
+        model.update(tags: [tag])
         #expect(model.title == "Updated")
         #expect(model.note == "Note")
+        #expect(model.tags?.count == 1)
     }
 }


### PR DESCRIPTION
## Summary
- prevent duplicate tag creation
- add multi-selection view for choosing tags
- show selected tags in stuff form
- update tests for tag creation and stuff intents
- use intents for tag operations

## Testing
- `pre-commit` *(fails: error 403 cloning SwiftLint)*
- `swift test -Xswiftc -enable-testing` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687246a543248320ad9f89f695b7df6c