### PR TITLE
Enable runtime debug mode

### DIFF
--- a/Bestuff/Sources/BestuffApp.swift
+++ b/Bestuff/Sources/BestuffApp.swift
@@ -27,6 +27,8 @@ struct BestuffApp: App {
 
     private var sharedStore: Store = .init()
     private var sharedConfigurationService: ConfigurationService = .init()
+    @AppStorage(BoolAppStorageKey.isDebugOn)
+    private var isDebugOn
 
     init() {
         sharedStore.open(
@@ -34,6 +36,9 @@ struct BestuffApp: App {
             productIDs: ["com.example.bestuff.subscription"],
             purchasedSubscriptionsDidSet: nil
         )
+#if DEBUG
+        isDebugOn = true
+#endif
     }
 
     var body: some Scene {

--- a/Bestuff/Sources/Shared/Models/AppStorageKey.swift
+++ b/Bestuff/Sources/Shared/Models/AppStorageKey.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 enum BoolAppStorageKey: String {
     case isSubscribeOn = "a018f613"
+    case isDebugOn = "a1B2c3D4"
 }
 
 extension AppStorage where Value == Bool {

--- a/Bestuff/Sources/Stuff/Views/StuffFormView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffFormView.swift
@@ -16,12 +16,16 @@ struct StuffFormView: View {
     @Environment(\.modelContext)
     private var modelContext
 
+    @AppStorage(BoolAppStorageKey.isDebugOn)
+    private var isDebugOn
+
     @State private var title = ""
     @State private var category = ""
     @State private var note = ""
     @State private var occurredAt = Date.now
     @State private var selectedTags: Set<Tag> = []
     @State private var isTagPickerPresented = false
+    @State private var isDebugDialogPresented = false
 
     var body: some View {
         Form {
@@ -62,7 +66,9 @@ struct StuffFormView: View {
         .navigationTitle(stuff == nil ? "Add Stuff" : "Edit Stuff")
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
-                CloseButton()
+                Button(action: cancel) {
+                    Text("Cancel")
+                }
             }
             ToolbarItem(placement: .confirmationAction) {
                 Button("Save", systemImage: "tray.and.arrow.down", action: save)
@@ -82,6 +88,18 @@ struct StuffFormView: View {
             NavigationStack {
                 TagPickerListView(selection: $selectedTags)
             }
+        }
+        .confirmationDialog(
+            "Debug",
+            isPresented: $isDebugDialogPresented
+        ) {
+            Button("OK", role: .destructive) {
+                isDebugOn = true
+                dismiss()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Are you really going to use DebugMode?")
         }
     }
 
@@ -117,6 +135,15 @@ struct StuffFormView: View {
             }
             dismiss()
         }
+    }
+
+    private func cancel() {
+        if title == "Enable Debug" {
+            title = .empty
+            isDebugDialogPresented = true
+            return
+        }
+        dismiss()
     }
 }
 

--- a/Bestuff/Sources/Stuff/Views/StuffListView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffListView.swift
@@ -25,6 +25,8 @@ struct StuffListView: View {
     @State private var isRecapPresented = false
     @State private var isPlanPresented = false
     @State private var isTagPresented = false
+    @AppStorage(BoolAppStorageKey.isDebugOn)
+    private var isDebugOn
 
     init(
         stuffs: [Stuff]? = nil,
@@ -105,11 +107,11 @@ struct StuffListView: View {
             ToolbarItem(placement: .secondaryAction) {
                 SettingsButton()
             }
-            #if DEBUG
-            ToolbarItem(placement: .secondaryAction) {
-                DebugButton()
+            if isDebugOn {
+                ToolbarItem(placement: .secondaryAction) {
+                    DebugButton()
+                }
             }
-            #endif
         }
         .sheet(isPresented: $isRecapPresented) {
             RecapNavigationView()


### PR DESCRIPTION
## Summary
- persist debug flag in AppStorage
- reorder environment and state properties in `StuffFormView`
- automatically enable debug mode on launch during development
- show or hide the Debug button with the toolbar item

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swiftlint` *(fails: Loading libsourcekitdInProc.so failed)*

------
https://chatgpt.com/codex/tasks/task_e_6872590ac9348320be5f6ce0a5c826f0