### PR TITLE
Add tag support to sample data

### DIFF
--- a/Bestuff/Resources/Localizable.xcstrings
+++ b/Bestuff/Resources/Localizable.xcstrings
@@ -40,6 +40,9 @@
         }
       }
     },
+    "Are you really going to use DebugMode?" : {
+
+    },
     "Best Stuff" : {
       "localizations" : {
         "ja" : {

--- a/Bestuff/Sources/Debug/Views/DebugListView.swift
+++ b/Bestuff/Sources/Debug/Views/DebugListView.swift
@@ -98,13 +98,16 @@ struct DebugListView: View {
         Logger(#file).info("Creating sample data")
         withAnimation {
             for stuff in SampleData.stuffs {
+                let tagModels: [Tag] = stuff.tags.map {
+                    Tag.findOrCreate(name: $0, in: modelContext)
+                }
                 _ = try? CreateStuffIntent.perform(
                     (
                         context: modelContext,
                         title: stuff.title,
                         note: stuff.note,
                         occurredAt: Date.now,
-                        tags: []
+                        tags: tagModels
                     )
                 )
             }
@@ -134,28 +137,34 @@ struct SampleData {
     struct StuffData {
         let title: String
         let note: String?
+        let tags: [String]
     }
 
     static let stuffs: [StuffData] = [
         .init(
             title: String(localized: "Coffee Beans"),
-            note: String(localized: "Order from the local roastery.")
+            note: String(localized: "Order from the local roastery."),
+            tags: [String(localized: "Groceries")]
         ),
         .init(
             title: String(localized: "Running Shoes"),
-            note: String(localized: "Replace the worn-out pair.")
+            note: String(localized: "Replace the worn-out pair."),
+            tags: [String(localized: "Fitness")]
         ),
         .init(
             title: String(localized: "Conference Tickets"),
-            note: String(localized: "WWDC 2025")
+            note: String(localized: "WWDC 2025"),
+            tags: [String(localized: "Work")]
         ),
         .init(
             title: String(localized: "Vacation Booking"),
-            note: String(localized: "Reserve hotel and flights.")
+            note: String(localized: "Reserve hotel and flights."),
+            tags: [String(localized: "Travel")]
         ),
         .init(
             title: String(localized: "Birthday Gift"),
-            note: String(localized: "Surprise for Alice.")
+            note: String(localized: "Surprise for Alice."),
+            tags: [String(localized: "Personal")]
         )
     ]
 }

--- a/Bestuff/Sources/Shared/Components/ModelContainerPreviewModifier.swift
+++ b/Bestuff/Sources/Shared/Components/ModelContainerPreviewModifier.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct ModelContainerPreviewModifier: PreviewModifier {
     static func makeSharedContext() throws -> ModelContainer {
-        let schema: Schema = .init([Stuff.self])
+        let schema: Schema = .init([Stuff.self, Tag.self])
         let configuration: ModelConfiguration = .init(
             schema: schema,
             isStoredInMemoryOnly: true
@@ -14,13 +14,16 @@ struct ModelContainerPreviewModifier: PreviewModifier {
         )
         let context: ModelContext = .init(container)
         for stuff in SampleData.stuffs {
+            let tagModels: [Tag] = stuff.tags.map {
+                Tag.findOrCreate(name: $0, in: context)
+            }
             _ = try? CreateStuffIntent.perform(
                 (
                     context: context,
                     title: stuff.title,
                     note: stuff.note,
                     occurredAt: .now,
-                    tags: []
+                    tags: tagModels
                 )
             )
         }


### PR DESCRIPTION
## Summary
- include tags when building sample data
- prepare preview context with Tag schema

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*
- `apt-get update` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_68842248164883208816cf9025128e98