### PR TITLE
Add missing Japanese localizations

### DIFF
--- a/Bestuff/Resources/Localizable.xcstrings
+++ b/Bestuff/Resources/Localizable.xcstrings
@@ -28,7 +28,14 @@
       }
     },
     "Add Tag" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タグを追加"
+          }
+        }
+      }
     },
     "App Version" : {
       "localizations" : {
@@ -41,7 +48,14 @@
       }
     },
     "Are you really going to use DebugMode?" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本当にデバッグモードを使用しますか？"
+          }
+        }
+      }
     },
     "Best Stuff" : {
       "localizations" : {
@@ -195,7 +209,14 @@
       }
     },
     "Create Tag" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タグを作成"
+          }
+        }
+      }
     },
     "Created %@" : {
       "localizations" : {
@@ -248,7 +269,14 @@
       }
     },
     "Done" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完了"
+          }
+        }
+      }
     },
     "Edit Stuff" : {
       "localizations" : {
@@ -261,7 +289,14 @@
       }
     },
     "Edit Tag" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タグを編集"
+          }
+        }
+      }
     },
     "Fitness" : {
       "localizations" : {
@@ -294,10 +329,24 @@
       }
     },
     "Get All Tags" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてのタグを取得"
+          }
+        }
+      }
     },
     "Get Tag By ID" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IDでタグを取得"
+          }
+        }
+      }
     },
     "Groceries" : {
       "localizations" : {
@@ -330,10 +379,24 @@
       }
     },
     "Name" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名前"
+          }
+        }
+      }
     },
     "New Tags (comma separated)" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新しいタグ（カンマ区切り）"
+          }
+        }
+      }
     },
     "Next Month" : {
       "localizations" : {
@@ -376,7 +439,14 @@
       }
     },
     "None" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "なし"
+          }
+        }
+      }
     },
     "Note" : {
       "localizations" : {
@@ -413,7 +483,14 @@
       "shouldTranslate" : false
     },
     "Open App Store" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App Store を開く"
+          }
+        }
+      }
     },
     "Options" : {
       "localizations" : {
@@ -496,7 +573,14 @@
       }
     },
     "Please update Bestuff to the latest version to continue using it." : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bestuff を最新バージョンに更新して使用を続けてください。"
+          }
+        }
+      }
     },
     "Predict" : {
       "localizations" : {
@@ -641,7 +725,14 @@
       }
     },
     "Select Tag" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タグを選択"
+          }
+        }
+      }
     },
     "Settings" : {
       "localizations" : {
@@ -704,7 +795,14 @@
       }
     },
     "Subscription" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サブスクリプション"
+          }
+        }
+      }
     },
     "Suggestion" : {
       "localizations" : {
@@ -737,13 +835,34 @@
       }
     },
     "Tag" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タグ"
+          }
+        }
+      }
     },
     "Tag ID" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タグ ID"
+          }
+        }
+      }
     },
     "Tags" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タグ"
+          }
+        }
+      }
     },
     "This Week" : {
       "localizations" : {
@@ -816,7 +935,14 @@
       }
     },
     "Update Required" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アップデートが必要です"
+          }
+        }
+      }
     },
     "Update Stuff" : {
       "localizations" : {
@@ -829,7 +955,14 @@
       }
     },
     "Update Tag" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タグを更新"
+          }
+        }
+      }
     },
     "Vacation Booking" : {
       "localizations" : {


### PR DESCRIPTION
## Summary
- Provide Japanese translations for previously untranslated UI strings like Add Tag, Done, and Update Required
- Ensure localization file uses consistent translated state entries

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895d4738fb48320b6e12303085bf3a2