### PR TITLE
fix: add logging for stuff detail layout issue

### DIFF
--- a/Bestuff/Resources/Localizable.xcstrings
+++ b/Bestuff/Resources/Localizable.xcstrings
@@ -218,7 +218,11 @@
         }
       }
     },
+    "Created" : {
+
+    },
     "Created %@" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ja" : {
           "stringUnit" : {
@@ -469,7 +473,11 @@
         }
       }
     },
+    "Occurred" : {
+
+    },
     "Occurred %@" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ja" : {
           "stringUnit" : {
@@ -683,6 +691,9 @@
           }
         }
       }
+    },
+    "Score" : {
+
     },
     "Score: %lld" : {
       "localizations" : {

--- a/Bestuff/Sources/Stuff/Views/StuffNavigationView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffNavigationView.swift
@@ -27,6 +27,12 @@ struct StuffNavigationView: View {
             }
         }
         .searchable(text: $searchText)
+        .onChange(of: selection) { newSelection in
+            Logger(#file).notice("Selection changed to \(String(describing: newSelection?.id))")
+        }
+        .onAppear {
+            Logger(#file).info("StuffNavigationView appeared")
+        }
     }
 }
 

--- a/Bestuff/Sources/Stuff/Views/StuffView.swift
+++ b/Bestuff/Sources/Stuff/Views/StuffView.swift
@@ -13,7 +13,7 @@ struct StuffView: View {
     private var stuff
 
     var body: some View {
-        List {
+        Form {
             if let note = stuff.note {
                 Section("Note") {
                     Text(note)
@@ -49,6 +49,9 @@ struct StuffView: View {
                 EditStuffButton()
                     .environment(stuff)
             }
+        }
+        .onAppear {
+            Logger(#file).info("StuffView appeared for id \(String(describing: stuff.id))")
         }
     }
 }


### PR DESCRIPTION
## Summary
- render stuff detail with `Form` instead of `List`
- log selection changes and detail appearance for debugging

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `pre-commit run --files Bestuff/Sources/Stuff/Views/StuffNavigationView.swift Bestuff/Sources/Stuff/Views/StuffView.swift` *(fails: error: RPC failed; HTTP 403 curl 22 The requested URL returned error: 403)*

------
https://chatgpt.com/codex/tasks/task_e_6895d94a2684832089a6febd4ba585ab