### PR TITLE
Fix crash when opening tag picker

### DIFF
--- a/Bestuff/Sources/Tag/Views/TagPickerListView.swift
+++ b/Bestuff/Sources/Tag/Views/TagPickerListView.swift
@@ -4,9 +4,8 @@ import SwiftUI
 struct TagPickerListView: View {
     @Environment(\.dismiss)
     private var dismiss
-    @Environment(\.modelContext)
-    private var modelContext
-    @State private var tags: [Tag] = []
+    @Query(sort: \Tag.name)
+    private var tags: [Tag]
 
     @Binding private var selection: Set<Tag>
 
@@ -29,11 +28,6 @@ struct TagPickerListView: View {
                 Button("Done") { dismiss() }
                     .buttonStyle(.borderedProminent)
                     .tint(.accentColor)
-            }
-        }
-        .task {
-            if let entities = try? GetAllTagsIntent.perform(modelContext) {
-                tags = entities.compactMap { try? $0.model(in: modelContext) }
             }
         }
     }


### PR DESCRIPTION
## Summary
- load tags with `@Query` instead of manual intent fetch in TagPickerListView

## Testing
- `swiftlint` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_6897f2ea41388320bb0ba7d8e287fb3b